### PR TITLE
Updated README.md to reflect correct tag values for reAlarm logic.

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,7 +539,7 @@ ReAlarm's behavior can be configured on a per alarm basis using tags.
 In addition to global controls, individual alarms can be excluded from being reset by ReAlarm. This is done using a specific tag:
 
 -   **Tag to Exclude Alarms from ReAlarm**:
-    -   Alarms can be tagged with `realarm:disabled=true` to exclude them from the ReAlarm process.
+    -   Alarms can be tagged with `autoalarm:re-alarm-enabled=false` to exclude them from the ReAlarm process.
     -   When this tag is present on an alarm, ReAlarm will skip resetting it, regardless of its state.
     -   This is useful for alarms that should be managed manually or have specific conditions that should not trigger ReAlarm.
 
@@ -547,15 +547,15 @@ In addition to global controls, individual alarms can be excluded from being res
 
 1. To prevent ReAlarm from resetting a particular alarm, add the following tag:
 
-    - **Key**: `autoalarm:re-alarm-disabled`
-    - **Value**: `true`
+    - **Key**: `autoalarm:re-alarm-enabled`
+    - **Value**: `false`
 
 2. **Tagging via AWS Console**:
 
     - Navigate to the CloudWatch alarm.
     - Under the "Tags" section, add a new tag:
-        - **Key**: `autoalarm:re-alarm-disabled`
-        - **Value**: `true`
+        - **Key**: `autoalarm:re-alarm-enabled`
+        - **Value**: `false`
 
 3. **Tagging via AWS CLI**:
     ```bash


### PR DESCRIPTION
README now correctly reflects autoalarm:re-alarm-enabled tag to disable reAlarm. 