### PR TITLE
This commit addresses two related issues:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # AutoAlarm Changelog
+## v1.10.3
+
+### Fixed:
+- Fixed issue where target group alarms were not properly cleaned up on deletion due to TargetGroupNotFoundException during the delete event processing workflow
+- Improved error handling for target group events with defensive programming to handle race conditions between delete and tag change events
+
 ## v1.10.2
 
 ### Fixed:
-- Fixed alarm filtering logic in NoBreachingExtendedQueue to correctly set TreatMissingData to 'notBreaching' for all SQS queue alarms using
+- Fixed alarm filtering logic in NoBreachingExtendedQueue to correctly set TreatMissingData to 'notBreaching' for all SQS queue alarms for default SQS queues.
 - Fixed statistic case in alarm configuration for OpenSearch metrics ('SUM' to 'Sum')
 
 ## v1.10.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoalarm",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "scripts": {
     "install-handlers": "cd handlers && pnpm i --frozen-lockfile",
     "install-cdk": "cd cdk && pnpm i --frozen-lockfile",


### PR DESCRIPTION
Issue-137: Fixed the target group alarm cleanup on deletion that was failing due to TargetGroupNotFoundException. The problem occurred because we were trying to describe a target group that had already been deleted. The fix:
- Extracts the target group name from ARN early in the process
- Processes delete events with a special flow that bypasses the describe call
- Returns early for delete events after calling manageInactiveTGAlarms
- Properly cleans up CloudWatch alarms when target groups are deleted

Issue-138: Implemented defensive programming to handle race conditions between delete and tag change events. When a target group is deleted but tag change events arrive out of order, we now:
- Safely handle TargetGroupNotFoundException in tag change events
- Add explicit error handling around the DescribeTargetGroupsCommand call
- Return early when a target group can't be described rather than throwing errors
- Improve code flow with clear comments and separate paths for different event types

Additional improvements:
- Added better documentation with clear code comments
- Improved error messages with more context
- Updated CHANGELOG.md for version 1.10.3
- Bumped package version in package.json