### PR TITLE
Issue 140

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,25 @@
 # AutoAlarm Changelog
+## v1.11.0
+
+### Added:
+- Implemented SQS-based message routing layer to resolve FIFO queue head-of-line blocking issues
+- Added content-based message group ID generation to prevent head-of-Line blocking in FIFO queues
+- Created dedicated SQS handler function that routes service-specific events to a single main function queue
+
+### Changed:
+- Refactored main-function-subconstruct to use a single consolidated FIFO queue instead of multiple service-specific queues
+- Improved CloudWatch API error handling by properly propagating throttling errors through the call chain
+- Enhanced resource naming and organization for better operational visibility and debugging
+- Optimized error recovery by ensuring failed operations can be properly retried without blocking other messages
+- AutoAlarm no longer fails SQS messages that contain error language in the message body
+- Changed queue visibility timeout from 900 seconds to 120 seconds for event source and main function queues
+
+### Fixed:
+- Fixed an issue where FIFO queue head-of-line blocking caused significant delays in event processing
+- Fixed error handling in CloudWatch alarm operations to ensure throttling errors are properly captured for retry
+- Improved error propagation in alarm-tools.mts to ensure failed alarm operations are properly recycled to SQS for retry
+
+
 ## v1.10.3
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Before you begin, ensure you have the following:
 
 1. **AWS CLI**: Installed and configured with appropriate access to your AWS account.
 2. **AWS CDK**
-3. **Node.js**
+3. **Node.js**: Version 22.x+.
 4. **Git**
 5. **pnpm**: Version 9.1.4 or later.
 

--- a/cdk/lib/auto-alarm-stack.ts
+++ b/cdk/lib/auto-alarm-stack.ts
@@ -14,7 +14,7 @@ export class AutoAlarmStack extends ExtendedStack {
   constructor(scope: Construct, id: string, props: ExtendedAutoAlarmProps) {
     // Use the extended interface here
     super(scope, id, props);
-    new AutoAlarmConstruct(this, 'AutoAlarm', {
+    new AutoAlarmConstruct(this, 'AutoAlarmConstruct', {
       prometheusWorkspaceId: props.prometheusWorkspaceId,
       enableReAlarm: props.enableReAlarm,
     });

--- a/cdk/lib/main-function-subsconstruct.ts
+++ b/cdk/lib/main-function-subsconstruct.ts
@@ -71,7 +71,7 @@ export class AutoAlarm extends Construct {
         fifo: true,
         contentBasedDeduplication: true,
         retentionPeriod: Duration.days(14),
-        visibilityTimeout: Duration.seconds(900),
+        visibilityTimeout: Duration.seconds(120),
         deadLetterQueue: {queue: dlq, maxReceiveCount: 3},
       },
     );

--- a/cdk/lib/main-function-subsconstruct.ts
+++ b/cdk/lib/main-function-subsconstruct.ts
@@ -99,7 +99,7 @@ export class AutoAlarm extends Construct {
       // Create queue with its own DLQ
       queues[queueName] = new NoBreachingExtendedQueue(
         this,
-        queueName.replace("'AutoAlarm-", ''),
+        queueName.replace('AutoAlarm-', ''),
         queueName,
         {
           fifo: true,

--- a/cdk/lib/sqs-handler-subconstruct.ts
+++ b/cdk/lib/sqs-handler-subconstruct.ts
@@ -162,7 +162,7 @@ export class SqsHandlerSubConstruct extends Construct {
     role: IRole,
     mainFunctionQueueURL: string,
   ): ExtendedNodejsFunction {
-    return new ExtendedNodejsFunction(this, 'ReAlarmProducerFunction', {
+    return new ExtendedNodejsFunction(this, 'SQSHandlerFunction', {
       entry: path.join(
         __dirname,
         '..',

--- a/cdk/lib/sqs-handler-subconstruct.ts
+++ b/cdk/lib/sqs-handler-subconstruct.ts
@@ -1,0 +1,187 @@
+import {ExtendedNodejsFunction} from 'truemark-cdk-lib/aws-lambda';
+import {
+  Effect,
+  IRole,
+  PolicyStatement,
+  Role,
+  ServicePrincipal,
+} from 'aws-cdk-lib/aws-iam';
+import {Construct} from 'constructs';
+import * as path from 'path';
+import {Duration} from 'aws-cdk-lib';
+import {Architecture} from 'aws-cdk-lib/aws-lambda';
+import {SqsEventSource} from 'aws-cdk-lib/aws-lambda-event-sources';
+import {NoBreachingExtendedQueue} from './extended-libs-subconstruct';
+
+export class SqsHandlerSubConstruct extends Construct {
+  public readonly lambdaFunction: ExtendedNodejsFunction;
+  public readonly eventSourceQueues: {
+    [key: string]: NoBreachingExtendedQueue;
+  } = {};
+
+  constructor(
+    scope: Construct,
+    id: string,
+    mainFunctionQueueArn: string,
+    mainFunctionQueueURL: string,
+  ) {
+    super(scope, id);
+    /**
+     * Set up the IAM role and policies for the sqs handler function
+     */
+    const role = this.createRole(mainFunctionQueueArn);
+
+    /**
+     * Create Node function definition
+     */
+    this.lambdaFunction = this.createFunction(role, mainFunctionQueueURL);
+
+    /**
+     * Create all the queues for all the services that AutoAlarm supports
+     */
+    this.eventSourceQueues = this.createQueues();
+  }
+
+  /**
+   * private method to create role and IAM policy for the function
+   */
+  private createRole(mainFunctionQueueArn: string): IRole {
+    /**
+     * Set up the IAM role and policies for the sqs handler function
+     */
+    const sqsHandlerExecutionRole = new Role(this, 'sqsHandlerExecutionRole', {
+      assumedBy: new ServicePrincipal('lambda.amazonaws.com'),
+      description: 'Execution role for AutoAlarm Lambda function',
+    });
+
+    // Grant permissions to send messages to the main function queue
+    sqsHandlerExecutionRole.addToPolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        resources: [mainFunctionQueueArn],
+        actions: [
+          'sqs:SendMessage',
+          'sqs:SendMessageBatch',
+          'sqs:GetQueueAttributes',
+          'sqs:GetQueueUrl',
+        ],
+      }),
+    );
+
+    // Grant permissions get queue info from source event queues
+
+    // Grant permissions to write logs to CloudWatch
+    sqsHandlerExecutionRole.addToPolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        resources: ['*'],
+        actions: [
+          'logs:CreateLogGroup',
+          'logs:CreateLogStream',
+          'logs:PutLogEvents',
+        ],
+      }),
+    );
+
+    return sqsHandlerExecutionRole;
+  }
+
+  /**
+   * Private method to create all the queues for all the services that AutoAlarm supports
+   */
+  private createQueues(): {[key: string]: NoBreachingExtendedQueue} {
+    //Create a string array of all the autoAlarmQueue names
+    const autoAlarmQueues = [
+      'AutoAlarm-Alb',
+      'AutoAlarm-Cloudfront',
+      'AutoAlarm-Ec2',
+      'AutoAlarm-OpenSearchRule',
+      'AutoAlarm-Rds',
+      'AutoAlarm-RdsCluster',
+      'AutoAlarm-Route53resolver',
+      'AutoAlarm-Sqs',
+      'AutoAlarm-Sfn',
+      'AutoAlarm-TargetGroup',
+      'AutoAlarm-TransitGateway',
+      'AutoAlarm-Vpn',
+    ];
+
+    //Create a custom object that contains/will constain all our fifo queues
+    const queues: {[key: string]: NoBreachingExtendedQueue} = {};
+
+    /**
+     * Loop through the autoAlarmQueues array and create a new ExtendedQueue object for each queue and add it to queues object
+     * Grant consume messages to the mainFunction for each queue
+     * Finally add an event source to the mainFunction for each queue
+     */
+    for (const queueName of autoAlarmQueues) {
+      // Create DLQ for each queue and let cdk handle the name generation after the queue name
+      const dlq = new NoBreachingExtendedQueue(
+        this,
+        `${queueName.replace('AutoAlarm-', '')}-Failed`,
+        queueName,
+        {
+          fifo: true,
+          retentionPeriod: Duration.days(14),
+        },
+      );
+
+      // Create queue with its own DLQ
+      queues[queueName] = new NoBreachingExtendedQueue(
+        this,
+        queueName.replace('AutoAlarm-', ''),
+        queueName,
+        {
+          fifo: true,
+          contentBasedDeduplication: true,
+          retentionPeriod: Duration.days(14),
+          visibilityTimeout: Duration.seconds(900),
+          deadLetterQueue: {queue: dlq, maxReceiveCount: 3},
+        },
+      );
+
+      queues[queueName].grantConsumeMessages(this.lambdaFunction);
+      this.lambdaFunction.addEventSource(
+        new SqsEventSource(queues[queueName], {
+          batchSize: 10,
+          reportBatchItemFailures: true,
+          enabled: true,
+        }),
+      );
+    }
+
+    return queues;
+  }
+
+  /**
+   * Private method to create the ReAlarm Producer function
+   * @param role - The IAM role for the ReAlarm Producer function
+   * @param mainFunctionQueueURL - The URL of the mainfunction queue to be passed as an environment variable
+   */
+  private createFunction(
+    role: IRole,
+    mainFunctionQueueURL: string,
+  ): ExtendedNodejsFunction {
+    return new ExtendedNodejsFunction(this, 'ReAlarmProducerFunction', {
+      entry: path.join(
+        __dirname,
+        '..',
+        '..',
+        'handlers',
+        'src',
+        'sqs-handler.mts',
+      ),
+      architecture: Architecture.ARM_64,
+      handler: 'handler',
+      timeout: Duration.minutes(15),
+      memorySize: 768,
+      role: role,
+      environment: {
+        TARGET_FIFO_QUEUE_URL: mainFunctionQueueURL,
+      },
+      deploymentOptions: {
+        createDeployment: false,
+      },
+    });
+  }
+}

--- a/cdk/lib/sqs-handler-subconstruct.ts
+++ b/cdk/lib/sqs-handler-subconstruct.ts
@@ -135,7 +135,7 @@ export class SqsHandlerSubConstruct extends Construct {
           fifo: true,
           contentBasedDeduplication: true,
           retentionPeriod: Duration.days(14),
-          visibilityTimeout: Duration.seconds(900),
+          visibilityTimeout: Duration.seconds(120),
           deadLetterQueue: {queue: dlq, maxReceiveCount: 3},
         },
       );

--- a/handlers/src/alarm-config.mts
+++ b/handlers/src/alarm-config.mts
@@ -1151,8 +1151,8 @@ export const MetricAlarmConfigs: Record<string, MetricAlarmConfig[]> = {
       defaultCreate: true,
       anomaly: true,
       defaults: {
-        warningThreshold: 2,
-        criticalThreshold: 6,
+        warningThreshold: 5,
+        criticalThreshold: 9,
         period: 300,
         evaluationPeriods: 2,
         statistic: 'Average',
@@ -1324,8 +1324,8 @@ export const MetricAlarmConfigs: Record<string, MetricAlarmConfig[]> = {
       defaultCreate: true,
       anomaly: true,
       defaults: {
-        warningThreshold: 2,
-        criticalThreshold: 6,
+        warningThreshold: 5,
+        criticalThreshold: 9,
         period: 300,
         evaluationPeriods: 2,
         statistic: 'Average',

--- a/handlers/src/main-handler.mts
+++ b/handlers/src/main-handler.mts
@@ -135,11 +135,21 @@ async function processEC2TagEvent(events: any[]) {
   }
 
   if (activeInstancesInfoArray.length > 0) {
-    await manageActiveEC2InstanceAlarms(activeInstancesInfoArray);
+    try {
+      await manageActiveEC2InstanceAlarms(activeInstancesInfoArray);
+    } catch (error) {
+      log.error().err(error).msg('Error managing active EC2 instance alarms');
+      throw new Error('Error managing active EC2 instance alarms');
+    }
   }
 
   if (inactiveInstancesInfoArray.length > 0) {
-    await manageInactiveInstanceAlarms(inactiveInstancesInfoArray);
+    try {
+      await manageInactiveInstanceAlarms(inactiveInstancesInfoArray);
+    } catch (error) {
+      log.error().err(error).msg('Error managing inactive EC2 instance alarms');
+      throw new Error('Error managing inactive EC2 instance alarms');
+    }
   }
 }
 

--- a/handlers/src/main-handler.mts
+++ b/handlers/src/main-handler.mts
@@ -220,8 +220,7 @@ async function routeTagEvent(event: any) {
   }
 }
 
-// TODO Fix the use of any
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+
 export const handler: Handler = async (
   event: SQSEvent,
 ): Promise<void | SQSBatchResponse> => {

--- a/handlers/src/main-handler.mts
+++ b/handlers/src/main-handler.mts
@@ -247,11 +247,9 @@ export const handler: Handler = async (
     // Check if the record body contains an error message
     if (record.body && record.body.includes('errorMessage')) {
       log
-        .error()
+        .warn()
         .str('messageId', record.messageId)
         .msg('Error message found in record body');
-      batchItemFailures.push({itemIdentifier: record.messageId});
-      batchItemBodies.push(record);
       continue;
     }
     // Parse the body of the SQS message

--- a/handlers/src/main-handler.mts
+++ b/handlers/src/main-handler.mts
@@ -220,7 +220,6 @@ async function routeTagEvent(event: any) {
   }
 }
 
-
 export const handler: Handler = async (
   event: SQSEvent,
 ): Promise<void | SQSBatchResponse> => {

--- a/handlers/src/realarm-consumer-handler.mts
+++ b/handlers/src/realarm-consumer-handler.mts
@@ -386,11 +386,9 @@ export const handler: SQSHandler = async (
       // Check if the record body contains an error message
       if (record.body && record.body.includes('errorMessage')) {
         log
-          .error()
+          .warn()
           .str('messageId', record.messageId)
           .msg('Error message found in record body');
-        batchItemFailures.push({itemIdentifier: record.messageId});
-        batchItemBodies.push(record);
         return null;
       }
       return JSON.parse(record.body) as AlarmMessage;

--- a/handlers/src/sqs-handler.mts
+++ b/handlers/src/sqs-handler.mts
@@ -30,99 +30,108 @@ const targetQueueUrl = process.env.TARGET_FIFO_QUEUE_URL;
 async function processRecord(record: SQSRecord): Promise<boolean> {
   try {
     // Log the message being processed
-    log.info()
-      .str('messageId', record.messageId)
-      .msg('Processing message');
-    
+    log.info().str('messageId', record.messageId).msg('Processing message');
+
     if (!targetQueueUrl) {
-      log.error()
+      log
+        .error()
         .str('messageId', record.messageId)
         .msg('Target FIFO queue URL not configured');
       return false;
     }
-    
+
     // Create a hash of the message body to use as a unique identifier
     const messageHash = crypto
       .createHash('sha256')
       .update(record.body)
       .digest('hex')
       .substring(0, 8);
-    
+
     // Create a unique message group ID by appending the hash to the message ID
     const messageGroupId = `${record.messageId}-${messageHash}`;
-    
+
     // Log routing details
-    log.debug()
+    log
+      .debug()
       .str('messageId', record.messageId)
       .str('targetQueue', targetQueueUrl)
       .str('messageGroupId', messageGroupId)
       .msg('Routing message to target FIFO queue');
-    
+
     // Prepare the message to send to the target queue
     const sendParams: SendMessageCommandInput = {
       QueueUrl: targetQueueUrl,
       MessageBody: record.body, // Forward the original message unchanged
       MessageGroupId: messageGroupId,
-      MessageDeduplicationId: `${record.messageId}-${Date.now()}`
+      MessageDeduplicationId: `${record.messageId}-${Date.now()}`,
     };
-    
+
     // Send the message to the target queue
     const response = await sqsClient.send(new SendMessageCommand(sendParams));
-    
+
     // Log success
-    log.info()
+    log
+      .info()
       .str('messageId', record.messageId)
       .str('newMessageId', response.MessageId || 'unknown')
       .str('messageGroupId', messageGroupId)
       .msg('Successfully routed message to target FIFO queue');
-    
+
     return true;
   } catch (error) {
     // Log error
-    log.error()
+    log
+      .error()
       .str('messageId', record.messageId)
       .err(error)
       .msg('Error processing message');
-    
+
     return false;
   }
 }
 
 // Lambda handler
-export const handler: Handler<SQSEvent, { batchItemFailures: { itemIdentifier: string }[] }> = async (event) => {
-  log.info()
+export const handler: Handler<
+  SQSEvent,
+  {batchItemFailures: {itemIdentifier: string}[]}
+> = async (event) => {
+  log
+    .info()
     .num('recordCount', event.Records.length)
     .msg('Received SQS event batch');
-  
-  const batchItemFailures: { itemIdentifier: string }[] = [];
-  
+
+  const batchItemFailures: {itemIdentifier: string}[] = [];
+
   // Process each record in the batch
   for (const record of event.Records) {
     try {
       const success = await processRecord(record);
-      
+
       if (!success) {
         // If processing failed, add to failures list
-        batchItemFailures.push({ itemIdentifier: record.messageId });
-        log.warn()
+        batchItemFailures.push({itemIdentifier: record.messageId});
+        log
+          .warn()
           .str('messageId', record.messageId)
           .msg('Adding message to batch item failures');
       }
     } catch (error) {
       // If an exception was thrown, add to failures list
-      batchItemFailures.push({ itemIdentifier: record.messageId });
-      log.error()
+      batchItemFailures.push({itemIdentifier: record.messageId});
+      log
+        .error()
         .str('messageId', record.messageId)
         .err(error)
         .msg('Unexpected error processing message');
     }
   }
-  
+
   // Return report of failed messages
-  log.info()
+  log
+    .info()
     .num('processedCount', event.Records.length)
     .num('failureCount', batchItemFailures.length)
     .msg('Completed processing message batch');
-  
-  return { batchItemFailures };
+
+  return {batchItemFailures};
 };

--- a/handlers/src/sqs-handler.mts
+++ b/handlers/src/sqs-handler.mts
@@ -48,7 +48,7 @@ async function processRecord(record: SQSRecord): Promise<boolean> {
       .substring(0, 8);
 
     // Create a unique message group ID by appending the hash to the message ID
-    const messageGroupId = `${record.messageId}-${messageHash}`;
+    const messageGroupId = `${record.attributes.MessageGroupId}-${messageHash}`;
 
     // Log routing details
     log
@@ -96,7 +96,8 @@ export const handler: Handler<
   {batchItemFailures: {itemIdentifier: string}[]}
 > = async (event) => {
   log
-    .info()
+    .trace()
+    .obj('event', event)
     .num('recordCount', event.Records.length)
     .msg('Received SQS event batch');
 

--- a/handlers/src/sqs-handler.mts
+++ b/handlers/src/sqs-handler.mts
@@ -110,8 +110,8 @@ export const handler: Handler = async (
           .str('messageId', record.messageId)
           .msg('Adding message to batch item failures');
       }
-    }));
-
+    }),
+  );
 
   // Return report of failed messages
   log

--- a/handlers/src/sqs-handler.mts
+++ b/handlers/src/sqs-handler.mts
@@ -1,0 +1,128 @@
+import {
+  SQSClient,
+  SendMessageCommand,
+  SendMessageCommandInput,
+} from '@aws-sdk/client-sqs';
+import {SQSEvent, SQSRecord, Handler} from 'aws-lambda';
+import * as logging from '@nr1e/logging';
+import * as crypto from 'crypto';
+
+// Initialize logging
+const level = process.env.LOG_LEVEL || 'trace';
+if (!logging.isLevel(level)) {
+  throw new Error(`Invalid log level: ${level}`);
+}
+const log = logging.initialize({
+  svc: 'AutoAlarm',
+  name: 'sqs-handler',
+  level,
+});
+
+// Initialize SQS client
+const sqsClient = new SQSClient({region: process.env.AWS_REGION});
+
+// Get the target FIFO queue URL from environment variables
+const targetQueueUrl = process.env.TARGET_FIFO_QUEUE_URL;
+
+// No service-specific functions needed
+
+// Function to process a single SQS record
+async function processRecord(record: SQSRecord): Promise<boolean> {
+  try {
+    // Log the message being processed
+    log.info()
+      .str('messageId', record.messageId)
+      .msg('Processing message');
+    
+    if (!targetQueueUrl) {
+      log.error()
+        .str('messageId', record.messageId)
+        .msg('Target FIFO queue URL not configured');
+      return false;
+    }
+    
+    // Create a hash of the message body to use as a unique identifier
+    const messageHash = crypto
+      .createHash('sha256')
+      .update(record.body)
+      .digest('hex')
+      .substring(0, 8);
+    
+    // Create a unique message group ID by appending the hash to the message ID
+    const messageGroupId = `${record.messageId}-${messageHash}`;
+    
+    // Log routing details
+    log.debug()
+      .str('messageId', record.messageId)
+      .str('targetQueue', targetQueueUrl)
+      .str('messageGroupId', messageGroupId)
+      .msg('Routing message to target FIFO queue');
+    
+    // Prepare the message to send to the target queue
+    const sendParams: SendMessageCommandInput = {
+      QueueUrl: targetQueueUrl,
+      MessageBody: record.body, // Forward the original message unchanged
+      MessageGroupId: messageGroupId,
+      MessageDeduplicationId: `${record.messageId}-${Date.now()}`
+    };
+    
+    // Send the message to the target queue
+    const response = await sqsClient.send(new SendMessageCommand(sendParams));
+    
+    // Log success
+    log.info()
+      .str('messageId', record.messageId)
+      .str('newMessageId', response.MessageId || 'unknown')
+      .str('messageGroupId', messageGroupId)
+      .msg('Successfully routed message to target FIFO queue');
+    
+    return true;
+  } catch (error) {
+    // Log error
+    log.error()
+      .str('messageId', record.messageId)
+      .err(error)
+      .msg('Error processing message');
+    
+    return false;
+  }
+}
+
+// Lambda handler
+export const handler: Handler<SQSEvent, { batchItemFailures: { itemIdentifier: string }[] }> = async (event) => {
+  log.info()
+    .num('recordCount', event.Records.length)
+    .msg('Received SQS event batch');
+  
+  const batchItemFailures: { itemIdentifier: string }[] = [];
+  
+  // Process each record in the batch
+  for (const record of event.Records) {
+    try {
+      const success = await processRecord(record);
+      
+      if (!success) {
+        // If processing failed, add to failures list
+        batchItemFailures.push({ itemIdentifier: record.messageId });
+        log.warn()
+          .str('messageId', record.messageId)
+          .msg('Adding message to batch item failures');
+      }
+    } catch (error) {
+      // If an exception was thrown, add to failures list
+      batchItemFailures.push({ itemIdentifier: record.messageId });
+      log.error()
+        .str('messageId', record.messageId)
+        .err(error)
+        .msg('Unexpected error processing message');
+    }
+  }
+  
+  // Return report of failed messages
+  log.info()
+    .num('processedCount', event.Records.length)
+    .num('failureCount', batchItemFailures.length)
+    .msg('Completed processing message batch');
+  
+  return { batchItemFailures };
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoalarm",
-  "version": "1.10.3",
+  "version": "1.11.0",
   "scripts": {
     "install-handlers": "cd handlers && pnpm i --frozen-lockfile",
     "install-cdk": "cd cdk && pnpm i --frozen-lockfile",


### PR DESCRIPTION
Fix FIFO queue head-of-line blocking issue with message routing layer (Issue #140)

  This commit addresses issue #140 where FIFO queue head-of-line blocking was causing
  significant delays in processing DeleteTargetGroup events, particularly when a
  load balancer was deleted before its associated target group.

  Key changes:

  1. Architectural enhancement:
     - Added new SQS routing layer via sqs-handler-subconstruct.ts that sits between
       EventBridge rules and the main function
     - Created sqs-handler.mts Lambda handler that routes messages to a single main
       function FIFO queue
     - Updated service-eventbridge-subconstruct.ts to target the new routing queues
     - Refactored main-function-subsconstruct.ts to use a single FIFO queue rather
       than multiple service-specific queues

  2. Message group ID isolation:
     - Implemented message hashing in sqs-handler.mts to generate unique message
       group IDs based on message content
     - Ensures that failures in one message don't block the entire message group
     - Each message now receives its own MessageGroupID derived from content hash:
       `${original-group-id}-${message-hash}`

  3. Error handling improvements:
     - Fixed error propagation in alarm-tools.mts by ensuring errors are properly
       rethrown rather than swallowed
     - Added proper error handling for CloudWatch API throttling scenarios

  This implementation solves the head-of-line blocking problem by ensuring that each
  message gets its own unique message group ID when routed to the main queue, preventing
  a single failing message from blocking all subsequent messages in the same service
  category.