### PR TITLE
Changing the defaultCreate to false on the Swap Usage alarm

### DIFF
--- a/handlers/src/alarm-configs/rds-configs.mts
+++ b/handlers/src/alarm-configs/rds-configs.mts
@@ -196,7 +196,7 @@ export const RDS_CONFIGS: MetricAlarmConfig[] = [
     tagKey: 'swap-usage',
     metricName: 'SwapUsage',
     metricNamespace: 'AWS/RDS',
-    defaultCreate: true,
+    defaultCreate: false,
     anomaly: false,
     defaults: {
       warningThreshold: 100000000,


### PR DESCRIPTION
Changing the defaultCreate to false on the Swap Usage alarm