### PR TITLE
Route CloudTrail VPN create/delete events to VPN handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # AutoAlarm Changelog
 
+## v1.14.4
+### Fixed
+- Fixed main handler not routing EC2 VPN create/delete events to the VPN module when events arrived in CloudTrail format. EventBridge sends VPN events with `detail-type` "AWS API Call via CloudTrail" and no `detail.resourceType`; the handler only routed when `resourceType === 'vpn-connection'`, so those events were treated as "Unhandled EC2 event format" and sent to the DLQ. Added an explicit branch for CloudTrail-form VPN create/delete events so they are routed to `parseVpnEventAndCreateAlarms` like the existing VPN path.
+
 ## v1.14.3
 ### Added
 - github workflows added

--- a/handlers/src/main-handler.mts
+++ b/handlers/src/main-handler.mts
@@ -290,6 +290,15 @@ export const handler: Handler = async (
             event['detail-type'] === 'EC2 Instance State-change Notification'
           ) {
             ec2Events.push(event);
+          } else if (
+            event.detail &&
+            event['detail-type'] === 'AWS API Call via CloudTrail' &&
+            event.detail.eventSource === 'ec2.amazonaws.com' &&
+            (event.detail.eventName === 'CreateVpnConnection' ||
+              event.detail.eventName === 'DeleteVpnConnection')
+          ) {
+            // CloudTrail VPN events have no detail.resourceType; route by detail-type and eventName
+            await ServiceModules.parseVpnEventAndCreateAlarms(event);
           } else if (event.detail && event.detail.resourceType) {
             // Handle other EC2 events that have a resourceType defined
             switch (event.detail.resourceType) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoalarm",
-  "version": "1.14.2",
+  "version": "1.14.3",
   "scripts": {
     "install-handlers": "cd handlers && pnpm i --frozen-lockfile",
     "install-cdk": "cd cdk && pnpm i --frozen-lockfile",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autoalarm",
-  "version": "1.14.3",
+  "version": "1.14.4",
   "scripts": {
     "install-handlers": "cd handlers && pnpm i --frozen-lockfile",
     "install-cdk": "cd cdk && pnpm i --frozen-lockfile",


### PR DESCRIPTION
EC2 VPN create/delete events emitted by EventBridge use the CloudTrail
payload shape (detail-type "AWS API Call via CloudTrail") and do not
include detail.resourceType. The main handler only routed to the VPN
module when event.detail.resourceType === 'vpn-connection', so these
events never reached parseVpnEventAndCreateAlarms and fell through to
the "Unhandled EC2 event format" path. That path reports batch item
failures, so messages were retried and eventually sent to the DLQ.

Add an explicit branch in the aws.ec2 case for CloudTrail-form VPN
events: when detail-type is "AWS API Call via CloudTrail",
eventSource is "ec2.amazonaws.com", and eventName is CreateVpnConnection
or DeleteVpnConnection, call parseVpnEventAndCreateAlarms(event). The
VPN module already supports this shape; only the main-handler routing
was missing.