### PR TITLE
Fix broken event routing (TGW/VPN/OpenSearch/ECS) and missing cloudwatch:TagResource permission

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -57,3 +57,7 @@ Start by cloning the project repository to your local machine:
     ```bash
     cd cdk ; cdk deploy AutoAlarm
     ```
+
+### Considerations
+
+- **CloudFront**: CloudFront is a global service. Its CloudTrail and tag-change events are delivered only in the `us-east-1` region. To use AutoAlarm's CloudFront alarm automation, deploy the stack (or a satellite event rule that forwards CloudFront events to it) in `us-east-1`.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ threshold values are provided in the tag value when setting the tag on the resou
 
 #### CloudFront
 
+> **Note:** CloudFront is a global service. Its CloudTrail and tag-change events are delivered only in the `us-east-1` region, so CloudFront alarm automation requires AutoAlarm (or a satellite event rule forwarding to it) to be deployed in `us-east-1`.
+
 | Tag                            | Alarm Created by Default | Standard CloudWatch Metric | Warning Threshold | Critical Threshold | Period | Evaluation Periods | Statistic | Datapoints to Alarm | Comparison Operator       | Missing Data Treatment | Complete Tag Value                                     |
 |--------------------------------|--------------------------|----------------------------|-------------------|--------------------|--------|--------------------|-----------|---------------------|---------------------------|------------------------|--------------------------------------------------------|
 | `autoalarm:4xx-errors`         | No                       | Yes                        | 100               | 300                | 300    | 1                  | Sum       | 1                   | GreaterThanThreshold      | ignore                 | `100/300/300/1/Sum/1/GreaterThanThreshold/ignore`      |

--- a/cdk/lib/auto-alarm-construct.ts
+++ b/cdk/lib/auto-alarm-construct.ts
@@ -6,10 +6,12 @@ import {Stack} from 'aws-cdk-lib';
 import {ReAlarmTagEventHandler} from './realarm-tag-event-subconstruct';
 import {EventRules} from './service-eventbridge-subconstruct';
 import {SqsHandlerSubConstruct} from './sqs-handler-subconstruct';
+import {CronOptions} from 'aws-cdk-lib/aws-events';
 
 interface AutoAlarmConstructProps {
   readonly prometheusWorkspaceId?: string;
   readonly enableReAlarm?: boolean;
+  readonly reAlarmSchedule?: CronOptions;
 }
 
 export class AutoAlarmConstruct extends Construct {
@@ -47,6 +49,7 @@ export class AutoAlarmConstruct extends Construct {
         accountId,
         this.reAlarmConsumer.reAlarmConsumerQueue.queueArn,
         this.reAlarmConsumer.reAlarmConsumerQueue.queueUrl,
+        props.reAlarmSchedule,
       );
 
       this.reAlarmTagEventHandler = new ReAlarmTagEventHandler(

--- a/cdk/lib/auto-alarm-stack.ts
+++ b/cdk/lib/auto-alarm-stack.ts
@@ -17,6 +17,7 @@ export class AutoAlarmStack extends ExtendedStack {
     new AutoAlarmConstruct(this, 'AutoAlarmConstruct', {
       prometheusWorkspaceId: props.prometheusWorkspaceId,
       enableReAlarm: props.enableReAlarm,
+      reAlarmSchedule: props.reAlarmSchedule,
     });
     this.outputParameter('Name', 'AutoAlarm');
     this.outputParameter('Version', version);

--- a/cdk/lib/main-function-subsconstruct.ts
+++ b/cdk/lib/main-function-subsconstruct.ts
@@ -141,6 +141,8 @@ export class AutoAlarm extends Construct {
           'cloudwatch:DescribeAlarms',
           'cloudwatch:ListMetrics',
           'cloudwatch:PutAnomalyDetector',
+          'cloudwatch:TagResource',
+          'cloudwatch:UntagResource',
         ],
         resources: ['*'],
       }),

--- a/cdk/lib/realarm-producer-subconstruct.ts
+++ b/cdk/lib/realarm-producer-subconstruct.ts
@@ -10,7 +10,7 @@ import {Construct} from 'constructs';
 import * as path from 'path';
 import {Duration} from 'aws-cdk-lib';
 import {Architecture} from 'aws-cdk-lib/aws-lambda';
-import {Rule, Schedule} from 'aws-cdk-lib/aws-events';
+import {CronOptions, Rule, Schedule} from 'aws-cdk-lib/aws-events';
 import {LambdaFunction} from 'aws-cdk-lib/aws-events-targets';
 
 export class ReAlarmProducer extends Construct {
@@ -22,6 +22,7 @@ export class ReAlarmProducer extends Construct {
     accountId: string,
     reAlarmConsumerQueueArn: string,
     reAlarmConsumerQueueURL: string,
+    reAlarmSchedule?: CronOptions,
   ) {
     super(scope, id);
     /**
@@ -52,7 +53,7 @@ export class ReAlarmProducer extends Construct {
     /**
      * Set up the EventBridge rule to trigger the ReAlarm Producer function
      */
-    this.createEventBridgeRules();
+    this.createEventBridgeRules(reAlarmSchedule);
   }
 
   /**
@@ -105,10 +106,13 @@ export class ReAlarmProducer extends Construct {
 
   /**
    * private method to up the EventBridge rule to trigger the ReAlarm Producer function
+   * @param reAlarmSchedule - Optional cron schedule override. Defaults to a rate of every 2 hours.
    */
-  private createEventBridgeRules(): void {
+  private createEventBridgeRules(reAlarmSchedule?: CronOptions): void {
     const reAlarmeScheduleRule = new Rule(this, 'ReAlarmScheduleRule', {
-      schedule: Schedule.rate(Duration.minutes(120)),
+      schedule: reAlarmSchedule
+        ? Schedule.cron(reAlarmSchedule)
+        : Schedule.rate(Duration.minutes(120)),
       description:
         'Default rule to trigger the ReAlarm Producer function every 2 hours',
     });

--- a/cdk/lib/service-eventbridge-subconstruct.ts
+++ b/cdk/lib/service-eventbridge-subconstruct.ts
@@ -325,9 +325,10 @@ export class EventRules extends Construct {
       openSearchStateRule: new Rule(this, 'OpenSearchStateRule', {
         eventPattern: {
           source: ['aws.es'],
-          detailType: ['Elasticsearch Service Domain Change'],
+          detailType: ['AWS API Call via CloudTrail'],
           detail: {
-            state: ['CreateDomain', 'DeleteDomain'],
+            eventSource: ['es.amazonaws.com'],
+            eventName: ['CreateDomain', 'DeleteDomain'],
           },
         },
         description: 'Routes OpenSearch events to AutoAlarm',
@@ -680,18 +681,16 @@ export class EventRules extends Construct {
         );
 
         if (!queueKey) {
-          console.warn(
+          throw new Error(
             `No queue found containing service name: ${serviceName}`,
           );
-          break;
         }
 
         const queue = queues[queueKey];
         const serviceRules = eventBridgeRules.serviceRules.get(serviceName);
 
         if (!serviceRules) {
-          console.warn(`No rules found for service: ${serviceName}`);
-          break;
+          throw new Error(`No rules found for service: ${serviceName}`);
         }
 
         serviceRules.forEach((ruleObj) => {

--- a/handlers/src/main-handler.mts
+++ b/handlers/src/main-handler.mts
@@ -161,12 +161,26 @@ async function routeTagEvent(event: any) {
     .msg('Processing tag event');
 
   switch (service) {
-    case 'transit-gateway':
-      await ServiceModules.parseTransitGatewayEventAndCreateAlarms(event);
-      break;
+    // Transit Gateway and VPN tag events arrive with service 'ec2' and are
+    // distinguished by resource-type. EC2 instance tag events are diverted
+    // before routeTagEvent is called.
+    case 'ec2':
+      switch (resourceType) {
+        case 'transit-gateway':
+          await ServiceModules.parseTransitGatewayEventAndCreateAlarms(event);
+          break;
 
-    case 'vpn-connection':
-      await ServiceModules.parseVpnEventAndCreateAlarms(event);
+        case 'vpn-connection':
+          await ServiceModules.parseVpnEventAndCreateAlarms(event);
+          break;
+
+        default:
+          log
+            .warn()
+            .str('function', 'routeTagEvent')
+            .msg(`Unhandled resource type for EC2: ${resourceType}`);
+          break;
+      }
       break;
 
     case 'elasticloadbalancing':
@@ -299,20 +313,20 @@ export const handler: Handler = async (
           ) {
             // CloudTrail VPN events have no detail.resourceType; route by detail-type and eventName
             await ServiceModules.parseVpnEventAndCreateAlarms(event);
+          } else if (
+            event.detail &&
+            event['detail-type'] === 'AWS API Call via CloudTrail' &&
+            event.detail.eventSource === 'ec2.amazonaws.com' &&
+            (event.detail.eventName === 'CreateTransitGateway' ||
+              event.detail.eventName === 'DeleteTransitGateway')
+          ) {
+            // CloudTrail Transit Gateway events have no detail.resourceType; route by detail-type and eventName
+            await ServiceModules.parseTransitGatewayEventAndCreateAlarms(event);
           } else if (event.detail && event.detail.resourceType) {
             // Handle other EC2 events that have a resourceType defined
             switch (event.detail.resourceType) {
               case 'instance':
                 ec2Events.push(event);
-                break;
-              case 'transit-gateway':
-                if (
-                  event.detail.eventName === 'CreateTransitGateway' ||
-                  event.detail.eventName === 'DeleteTransitGateway'
-                )
-                  await ServiceModules.parseTransitGatewayEventAndCreateAlarms(
-                    event,
-                  );
                 break;
               case 'vpn-connection':
                 if (
@@ -357,6 +371,8 @@ export const handler: Handler = async (
           }
           break;
 
+        // OpenSearch CloudTrail events arrive with source 'aws.es'
+        case 'aws.es':
         case 'aws.opensearch':
           await ServiceModules.parseOSEventAndCreateAlarms(event);
           break;

--- a/handlers/src/service-modules/ecs-modules.mts
+++ b/handlers/src/service-modules/ecs-modules.mts
@@ -242,11 +242,14 @@ export async function parseECSEventAndCreateAlarms(
   const serviceInfo = extractECSServiceInfo(record.body, accountId);
 
   if (!serviceInfo) {
+    // TagResource/UntagResource events are forwarded for all ECS resource types
+    // (clusters, task definitions, etc.) - only service events are actionable
     log
-      .error()
+      .warn()
       .str('function', 'parseECSEventAndCreateAlarms')
-      .msg('Failed to extract ECS service info from event');
-    throw new Error('No valid ECS service info found in event');
+      .str('eventName', eventName)
+      .msg('Event does not reference an ECS service - skipping');
+    return;
   }
 
   const {serviceArn, serviceName, clusterName} = serviceInfo;

--- a/handlers/src/service-modules/transit-gateway-modules.mts
+++ b/handlers/src/service-modules/transit-gateway-modules.mts
@@ -288,13 +288,22 @@ export async function parseTransitGatewayEventAndCreateAlarms(
         .msg('Unexpected event type');
   }
 
-  const transitGatewayName = extractTransitGatewayNameFromArn(transitGatewayId);
+  // CloudTrail events provide a bare id ('tgw-...') while tag events provide a
+  // full ARN. Only run ARN extraction when the value is not already a bare id.
+  const transitGatewayName = transitGatewayId?.startsWith('tgw-')
+    ? transitGatewayId
+    : extractTransitGatewayNameFromArn(transitGatewayId || '');
   if (!transitGatewayName) {
     log
       .error()
       .str('function', 'parseTransitGatewayEventAndCreateAlarms')
       .str('transitGatewayId', transitGatewayId)
-      .msg('Extracted Transit Gateway name is empty');
+      .msg(
+        'Could not resolve Transit Gateway identifier from event. Failing record to avoid managing alarms with an empty identifier',
+      );
+    throw new Error(
+      'Could not resolve Transit Gateway identifier from event. Cannot manage alarms with an empty identifier',
+    );
   }
 
   log

--- a/handlers/src/service-modules/vpn-modules.mts
+++ b/handlers/src/service-modules/vpn-modules.mts
@@ -205,7 +205,9 @@ export async function parseVpnEventAndCreateAlarms(
 
   switch (event['detail-type']) {
     case 'Tag Change on Resource':
-      vpnId = event.resources[0];
+      // resources[0] is a full ARN (arn:aws:ec2:...:vpn-connection/vpn-xxx);
+      // extract the bare 'vpn-...' id to match the VpnId dimension and alarm names
+      vpnId = event.resources[0]?.split('/').pop() || '';
       eventType = 'TagChange';
       tags = event.detail.tags || {};
       log
@@ -281,7 +283,12 @@ export async function parseVpnEventAndCreateAlarms(
       .error()
       .str('function', 'parseVpnEventAndCreateAlarms')
       .str('vpnId', vpnId)
-      .msg('Vpn Id is empty');
+      .msg(
+        'Could not resolve VPN identifier from event. Failing record to avoid managing alarms with an empty identifier',
+      );
+    throw new Error(
+      'Could not resolve VPN identifier from event. Cannot manage alarms with an empty identifier',
+    );
   }
 
   log


### PR DESCRIPTION
PR 1 of a 9-PR series implementing findings from a verified code review of AutoAlarm.

## Findings fixed

- **[CRITICAL] Missing `cloudwatch:TagResource` permission** — `cdk/lib/main-function-subsconstruct.ts`: the main handler always sends `Tags` in `PutMetricAlarmCommand` (`alarm-tools.mts`), so creating any new alarm failed with AccessDenied. Added `cloudwatch:TagResource`/`cloudwatch:UntagResource` (re-applies reverted commit f88c3f3).
- **[CRITICAL] TGW/VPN tag events silently dropped** — `handlers/src/main-handler.mts` `routeTagEvent`: tag events arrive with `detail.service='ec2'` and `detail['resource-type']='transit-gateway'|'vpn-connection'`, but the switch matched on `service` with cases `'transit-gateway'`/`'vpn-connection'` that never fired. Now routes `service==='ec2'` by resource-type (EC2 instance tag events are still diverted earlier, unchanged).
- **[HIGH] TGW CloudTrail events sent to DLQ** — `handlers/src/main-handler.mts`: `CreateTransitGateway`/`DeleteTransitGateway` CloudTrail events have no `detail.resourceType` and hit 'Unhandled EC2 event format'. Added a special case mirroring the existing VPN handling; removed the now-unreachable `case 'transit-gateway':` under the resourceType switch.
- **[HIGH] TGW identifier resolution could mass-delete all TGW alarms** — `handlers/src/service-modules/transit-gateway-modules.mts`: CloudTrail branches yield a bare `tgw-...` id but `extractTransitGatewayNameFromArn` only matches ARNs, producing `''`; the Delete branch then called `deleteExistingAlarms('TGW','')`, which prefix-matches **every** TGW alarm. Bare ids are now used directly, ARN extraction only runs on ARNs, and an empty resolved identifier now logs an error and throws so the record fails visibly.
- **[HIGH] VPN tag events used full ARN as VpnId** — `handlers/src/service-modules/vpn-modules.mts`: the TagChange branch set `vpnId = event.resources[0]` (an ARN), which flowed into the `VpnId` dimension (matching no metric) and alarm names. Now extracts the bare `vpn-...` id and applies the same empty-identifier guard.
- **[HIGH] OpenSearch create/delete events never matched** — `cdk/lib/service-eventbridge-subconstruct.ts` `OpenSearchStateRule` matched a nonexistent detail-type 'Elasticsearch Service Domain Change'; `CreateDomain`/`DeleteDomain` are CloudTrail events. Rule now matches `source: aws.es` + CloudTrail eventName, and `main-handler.mts` now routes source `'aws.es'` (previously only `'aws.opensearch'`) to the OpenSearch module.
- **[MEDIUM] Routine ECS tagging poisoned messages to the DLQ** — `handlers/src/service-modules/ecs-modules.mts`: the CDK rule forwards `TagResource`/`UntagResource` for all ECS resource types (clusters, task definitions), but the parser threw when no service ARN was present. Now logs a structured warn and returns.
- **[MEDIUM] Silent target-wiring skips at synth time** — `cdk/lib/service-eventbridge-subconstruct.ts` `eventRuleTargetSetter` used `break` (with only console.warn) when a queue or rule list was missing, silently skipping all remaining services. Now throws at synth time.
- **[MEDIUM] `reAlarmSchedule` prop was accepted but never used** — producer schedule was hardcoded `rate(120 minutes)`. Wired the optional `CronOptions` through `AutoAlarmConstruct` → `ReAlarmProducer`; uses `Schedule.cron(...)` when provided, else keeps the 2-hour default.
- **[LOW/docs] CloudFront region note** — README.md and DEPLOYMENT.md now note that CloudFront CloudTrail/tag events are delivered only in us-east-1, so CloudFront alarm automation requires the stack (or a satellite rule) there.

## Notes

- The TGW/VPN identifier fixes are included in this PR because the routing fixes activate those previously-dead code paths — without them, the first DeleteTransitGateway event would have deleted **all** TGW alarms.
- Verified: `pnpm exec tsc --noEmit`, prettier, eslint, and `vitest` (13/13) in `handlers/`; `pnpm run build` (prettier + eslint + tsc) and `pnpm test` in `cdk/`.