### PR TITLE
Fix AMP namespace race via EC2 FIFO serialization; stop swallowing rule errors; fix PromQL instance regex and identity matching

### DIFF
--- a/handlers/src/alarm-configs/utils/prometheus-queries.mts
+++ b/handlers/src/alarm-configs/utils/prometheus-queries.mts
@@ -1,4 +1,8 @@
 // EC2 Prometheus queries for prometheus rules
+// Note: the instance label is matched as either "<privateIp>" or "<privateIp>:<port>".
+// A ".*" suffix after the IP would also match longer IPs (e.g. 10.0.1.5 would
+// match 10.0.1.50:9100), causing cross-instance alerts, so we only allow an
+// optional port suffix via "(:\\d+)?".
 export function EC2getCpuQuery(
   platform: string | null,
   escapedPrivateIp: string,
@@ -6,9 +10,9 @@ export function EC2getCpuQuery(
   threshold: number,
 ): string {
   if (platform?.toLowerCase().includes('windows')) {
-    return `100 - (rate(windows_cpu_time_total{instance=~"(${escapedPrivateIp}.*|${instanceId})", mode="idle"}[180s]) * 100) > ${threshold}`;
+    return `100 - (rate(windows_cpu_time_total{instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})", mode="idle"}[180s]) * 100) > ${threshold}`;
   } else {
-    return `100 - (rate(node_cpu_seconds_total{mode="idle", instance=~"(${escapedPrivateIp}.*|${instanceId})"}[180s]) * 100) > ${threshold}`;
+    return `100 - (rate(node_cpu_seconds_total{mode="idle", instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})"}[180s]) * 100) > ${threshold}`;
   }
 }
 
@@ -19,9 +23,9 @@ export function EC2getMemoryQuery(
   threshold: number,
 ): string {
   if (platform?.toLowerCase().includes('windows')) {
-    return `100 - ((windows_os_virtual_memory_free_bytes{instance=~"(${escapedPrivateIp}.*|${instanceId})"} / windows_os_virtual_memory_bytes{instance=~"(${escapedPrivateIp}.*|${instanceId})"}) * 100) > ${threshold}`;
+    return `100 - ((windows_os_virtual_memory_free_bytes{instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})"} / windows_os_virtual_memory_bytes{instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})"}) * 100) > ${threshold}`;
   } else {
-    return `100 - ((node_memory_MemAvailable_bytes{instance=~"(${escapedPrivateIp}.*|${instanceId})"} / node_memory_MemTotal_bytes{instance=~"(${escapedPrivateIp}.*|${instanceId})"}) * 100) > ${threshold}`;
+    return `100 - ((node_memory_MemAvailable_bytes{instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})"} / node_memory_MemTotal_bytes{instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})"}) * 100) > ${threshold}`;
   }
 }
 
@@ -32,8 +36,8 @@ export function EC2getStorageQuery(
   threshold: number,
 ): string {
   if (platform?.toLowerCase().includes('windows')) {
-    return `100 - ((windows_logical_disk_free_bytes{instance=~"(${escapedPrivateIp}.*|${instanceId})"} / windows_logical_disk_size_bytes{instance=~"(${escapedPrivateIp}.*|${instanceId})"}) * 100) > ${threshold}`;
+    return `100 - ((windows_logical_disk_free_bytes{instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})"} / windows_logical_disk_size_bytes{instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})"}) * 100) > ${threshold}`;
   } else {
-    return `100 - ((node_filesystem_free_bytes{instance=~"(${escapedPrivateIp}.*|${instanceId})"} / node_filesystem_size_bytes{instance=~"(${escapedPrivateIp}.*|${instanceId})"}) * 100) > ${threshold}`;
+    return `100 - ((node_filesystem_free_bytes{instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})"} / node_filesystem_size_bytes{instance=~"(${escapedPrivateIp}(:\\\\d+)?|${instanceId})"}) * 100) > ${threshold}`;
   }
 }

--- a/handlers/src/alarm-configs/utils/prometheus-tools.mts
+++ b/handlers/src/alarm-configs/utils/prometheus-tools.mts
@@ -8,6 +8,7 @@ import {
   DescribeWorkspaceCommandInput,
   ListRuleGroupsNamespacesCommand,
   PutRuleGroupsNamespaceCommand,
+  RuleGroupsNamespaceStatusCode,
   RuleGroupsNamespaceSummary,
 } from '@aws-sdk/client-amp';
 import {
@@ -32,7 +33,13 @@ import {buildAlarmName, parseMetricAlarmOptions} from './index.mjs';
 import * as AlarmConfigs from '../_index.mjs';
 
 const log: logging.Logger = logging.getLogger('ec2-modules');
-const retryStrategy = new ConfiguredRetryStrategy(20);
+// Keep the SDK-level retries modest: these calls are also wrapped in
+// retryWithExponentialBackoff, so a large SDK retry count multiplies the
+// total retry time.
+const retryStrategy = new ConfiguredRetryStrategy(
+  5,
+  (attempt: number) => 100 + attempt * 1000,
+);
 //the following environment variables are used to get the prometheus workspace id and the region
 const region: string = process.env.AWS_REGION || '';
 const client = new AmpClient({
@@ -44,13 +51,13 @@ const client = new AmpClient({
 /*
  * Exponential backoff retry helper function. This is used because the built-in aws retry strategy doesn't work in this
  * context as failed calls during update.
- * first delay starts at 30 seconds and then increments by 15 seconds for each iteration.
+ * first delay starts at 5 seconds and then increments by 5 seconds for each iteration.
  */
 async function retryWithExponentialBackoff(
   fn: () => Promise<void>,
-  maxRetries = 5,
-  initialDelay = 30000, // Initial delay in milliseconds (30 seconds)
-  delayIncrement = 15000, // Incremental delay in milliseconds (15 seconds)
+  maxRetries = 3,
+  initialDelay = 5000, // Initial delay in milliseconds (5 seconds)
+  delayIncrement = 5000, // Incremental delay in milliseconds (5 seconds)
 ) {
   let attempt = 0;
 
@@ -148,6 +155,9 @@ export async function batchPromRulesDeletion(
       .str('function', 'batchPromRulesDeletion')
       .err(error)
       .msg('Error deleting Prometheus rules.');
+    // Rethrow so callers don't treat failed deletions as success and leave
+    // stale Prometheus rules behind (e.g. for terminated instances).
+    throw error;
   }
 }
 
@@ -602,24 +612,64 @@ export async function queryPrometheusForService(
 }
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-// Function to list namespaces
+
+// Errors that will never succeed on retry and should be rethrown immediately.
+const nonRetryableListErrors = ['AccessDeniedException', 'ValidationException'];
+
+// Function to list namespaces. Paginates via nextToken so all namespaces are
+// returned (the 2000-rule guard depends on a complete count) and retries
+// transient errors a bounded number of times instead of recursing forever.
 const listNamespaces = async (
   workspaceId: string,
 ): Promise<RuleGroupsNamespaceSummary[]> => {
-  const command = new ListRuleGroupsNamespacesCommand({workspaceId});
   log.info().str('workspaceId', workspaceId).msg('Listing namespaces');
-  try {
-    const response = await client.send(command);
-    log
-      .info()
-      .str('response', JSON.stringify(response))
-      .msg('Successfully listed namespaces');
-    return response.ruleGroupsNamespaces ?? [];
-  } catch (error) {
-    log.error().err(error).msg('Error listing namespaces');
-    await wait(60000); // Wait for 60 seconds before retrying
-    return listNamespaces(workspaceId);
+  const maxAttempts = 3;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    try {
+      const namespaces: RuleGroupsNamespaceSummary[] = [];
+      let nextToken: string | undefined;
+      do {
+        const response = await client.send(
+          new ListRuleGroupsNamespacesCommand({workspaceId, nextToken}),
+        );
+        namespaces.push(...(response.ruleGroupsNamespaces ?? []));
+        nextToken = response.nextToken;
+      } while (nextToken);
+
+      log
+        .info()
+        .num('namespaceCount', namespaces.length)
+        .msg('Successfully listed namespaces');
+      return namespaces;
+    } catch (error) {
+      const errorName = error instanceof Error ? error.name : '';
+      if (nonRetryableListErrors.includes(errorName)) {
+        log
+          .error()
+          .err(error)
+          .msg('Non-retryable error listing namespaces. Not retrying.');
+        throw error;
+      }
+      if (attempt >= maxAttempts) {
+        log
+          .error()
+          .err(error)
+          .num('attempt', attempt)
+          .msg('Error listing namespaces. Exceeded maximum retries.');
+        throw error;
+      }
+      log
+        .warn()
+        .err(error)
+        .num('attempt', attempt)
+        .msg('Error listing namespaces. Retrying.');
+      await wait(5000); // Wait for 5 seconds before retrying
+    }
   }
+
+  // Unreachable: the loop either returns or throws.
+  return [];
 };
 
 // Function to describe a namespace
@@ -732,19 +782,102 @@ async function createNamespace(
   try {
     const command = new CreateRuleGroupsNamespaceCommand(input);
     await client.send(command);
+    log
+      .info()
+      .str('function', 'createNamespace')
+      .str('namespace', namespace)
+      .msg('Created new namespace and added rules');
   } catch (error) {
     log
       .error()
       .str('function', 'createNamespace')
       .err(error)
       .msg('Failed to create namespace');
+    // Rethrow so callers don't treat a failed create as success and silently
+    // drop every rule (e.g. ConflictException on a concurrent create).
+    throw error;
+  }
+}
+
+/**
+ * Polls DescribeRuleGroupsNamespace until the namespace reaches ACTIVE status.
+ * Replaces fixed sleeps after namespace creation so we only wait as long as
+ * AMP actually needs.
+ * @param promWorkspaceId - The Prometheus workspace ID.
+ * @param namespace - The namespace name.
+ * @param pollIntervalMs - How often to poll (default 5 seconds).
+ * @param timeoutMs - Maximum time to wait before failing (default 120 seconds).
+ */
+async function waitForNamespaceActive(
+  promWorkspaceId: string,
+  namespace: string,
+  pollIntervalMs = 5000,
+  timeoutMs = 120000,
+) {
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    try {
+      const response = await client.send(
+        new DescribeRuleGroupsNamespaceCommand({
+          workspaceId: promWorkspaceId,
+          name: namespace,
+        }),
+      );
+      const statusCode = response.ruleGroupsNamespace?.status?.statusCode;
+
+      if (statusCode === RuleGroupsNamespaceStatusCode.ACTIVE) {
+        log
+          .info()
+          .str('function', 'waitForNamespaceActive')
+          .str('namespace', namespace)
+          .msg('Namespace is active');
+        return;
+      }
+
+      if (
+        statusCode === RuleGroupsNamespaceStatusCode.CREATION_FAILED ||
+        statusCode === RuleGroupsNamespaceStatusCode.UPDATE_FAILED
+      ) {
+        log
+          .error()
+          .str('function', 'waitForNamespaceActive')
+          .str('namespace', namespace)
+          .str('statusCode', statusCode)
+          .msg('Namespace entered a failed state');
+        throw new Error(
+          `Namespace ${namespace} entered failed state: ${statusCode}`,
+        );
+      }
+
+      log
+        .info()
+        .str('function', 'waitForNamespaceActive')
+        .str('namespace', namespace)
+        .str('statusCode', statusCode ?? 'unknown')
+        .msg('Namespace not active yet. Waiting before polling again.');
+    } catch (error) {
+      // The namespace may not be visible immediately after creation. Keep
+      // polling on ResourceNotFoundException; rethrow anything else.
+      if (
+        !(error instanceof Error) ||
+        error.name !== 'ResourceNotFoundException'
+      ) {
+        throw error;
+      }
+      log
+        .info()
+        .str('function', 'waitForNamespaceActive')
+        .str('namespace', namespace)
+        .msg('Namespace not found yet. Waiting before polling again.');
+    }
+
+    await wait(pollIntervalMs);
   }
 
-  log
-    .info()
-    .str('function', 'createNamespace')
-    .str('namespace', namespace)
-    .msg('Created new namespace and added rules');
+  throw new Error(
+    `Timed out waiting for namespace ${namespace} to become active after ${timeoutMs}ms`,
+  );
 }
 
 // Helper function to ensure that the object is a NamespaceDetails interface
@@ -831,16 +964,21 @@ export async function managePromNamespaceAlarms(
     .str('namespace', namespace)
     .msg('Retrieved namespaces');
 
+  // Describe all namespaces in parallel and reuse the results below instead of
+  // re-describing the target namespace.
+  const describedNamespaces = await Promise.all(
+    namespaces.map(async (ns) => ({
+      name: ns.name as string,
+      details: await describeNamespace(promWorkspaceId, ns.name as string),
+    })),
+  );
+
   let totalWSRules = 0;
   // Count total rules across all namespaces
-  for (const ns of namespaces) {
-    const nsDetails = await describeNamespace(
-      promWorkspaceId,
-      ns.name as string,
-    );
-    if (nsDetails && isNamespaceDetails(nsDetails)) {
+  for (const {details} of describedNamespaces) {
+    if (details && isNamespaceDetails(details)) {
       // Add the number of rules in the current namespace to the total count
-      totalWSRules += nsDetails.groups.reduce(
+      totalWSRules += details.groups.reduce(
         (count, group) => count + group.rules.length,
         0,
       );
@@ -877,14 +1015,15 @@ export async function managePromNamespaceAlarms(
       .str('function', 'managePromNamespaceAlarms')
       .str('namespace', namespace)
       .msg(
-        'Created new namespace and added rules. Waiting 90 seconds to allow namespace to propagate.',
+        'Created new namespace and added rules. Waiting for namespace to become active.',
       );
-    await wait(90000); // Wait for 90 seconds after creating the namespace
+    await waitForNamespaceActive(promWorkspaceId, namespace);
     return;
   }
 
-  // Describe the specific namespace to get its details
-  const nsDetails = await describeNamespace(promWorkspaceId, namespace);
+  // Reuse the namespace details fetched above for the rule count
+  const nsDetails =
+    describedNamespaces.find((ns) => ns.name === namespace)?.details ?? null;
   if (!nsDetails || !isNamespaceDetails(nsDetails)) {
     log
       .warn()
@@ -922,7 +1061,10 @@ export async function managePromNamespaceAlarms(
         .info()
         .str('function', 'managePromNamespaceAlarms')
         .str('namespace', namespace)
-        .msg('Recreated namespace with updated rules.');
+        .msg(
+          'Recreated namespace with updated rules. Waiting for namespace to become active.',
+        );
+      await waitForNamespaceActive(promWorkspaceId, namespace);
       return;
     } catch (error) {
       log
@@ -937,10 +1079,16 @@ export async function managePromNamespaceAlarms(
     }
   }
 
-  // Find the rule group within the namespace or create a new one
-  const ruleGroup = nsDetails.groups.find(
+  // Find the rule group within the namespace or create a new one. A newly
+  // created rule group must be pushed into nsDetails.groups, otherwise the
+  // rules added to it are silently dropped when nsDetails is dumped to YAML.
+  let ruleGroup = nsDetails.groups.find(
     (rg): rg is RuleGroup => rg.name === ruleGroupName,
-  ) || {name: ruleGroupName, rules: []};
+  );
+  if (!ruleGroup) {
+    ruleGroup = {name: ruleGroupName, rules: []};
+    nsDetails.groups.push(ruleGroup);
+  }
 
   // Iterate over the alarm configurations and update or add rules
   for (const config of alarmConfigs) {

--- a/handlers/src/service-modules/ec2-modules.mts
+++ b/handlers/src/service-modules/ec2-modules.mts
@@ -567,6 +567,17 @@ export async function manageActiveEC2InstanceAlarms(
         const isWindows = ec2Metadata.platform?.includes('Windows') || false;
         const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
 
+        /*
+         * queryPrometheusForService returns a mix of instance IDs and bare
+         * private IPs (the 'instance' label is often ip:port, which is
+         * stripped to the bare IP), so membership must be checked against
+         * BOTH the instance ID and the instance's private IP.
+         */
+        const reportsToPrometheus =
+          instanceIDsReportingToPrometheus.includes(instanceID) ||
+          (!!ec2Metadata.privateIP &&
+            instanceIDsReportingToPrometheus.includes(ec2Metadata.privateIP));
+
         if (!isAlarmEnabled) {
           log
             .info()
@@ -587,8 +598,7 @@ export async function manageActiveEC2InstanceAlarms(
         if (
           prometheusWorkspaceId &&
           (tags['autoalarm:target'] === 'prometheus' ||
-            (!tags['autoalarm:target'] &&
-              instanceIDsReportingToPrometheus.includes(instanceID)))
+            (!tags['autoalarm:target'] && reportsToPrometheus))
         ) {
           log
             .info()
@@ -633,10 +643,8 @@ export async function manageActiveEC2InstanceAlarms(
           prometheusArray.push({instanceID, tags, state, ec2Metadata});
         } else if (
           tags['autoalarm:target'] === 'cloudwatch' ||
-          (!tags['autoalarm:target'] &&
-            !instanceIDsReportingToPrometheus.includes(instanceID)) ||
-          (tags['autoalarm:target'] === 'prometheus' &&
-            !instanceIDsReportingToPrometheus.includes(instanceID))
+          (!tags['autoalarm:target'] && !reportsToPrometheus) ||
+          (tags['autoalarm:target'] === 'prometheus' && !reportsToPrometheus)
         ) {
           log
             .info()
@@ -647,7 +655,7 @@ export async function manageActiveEC2InstanceAlarms(
               'autoalarm target set to cloudwatch. Creating cloudwatch alarms in place of prometheus alarms',
             );
 
-          if (instanceIDsReportingToPrometheus.includes(instanceID)) {
+          if (reportsToPrometheus) {
             deletePrometheusAlarmsArray.push({
               instanceID,
               tags,
@@ -805,10 +813,20 @@ export async function manageInactiveInstanceAlarms(
   const prometheusAlarmsToDelete: EC2AlarmManagerArray = [];
   for (const instanceInfo of inactiveInstancesInfoArray) {
     const ec2MetaData = await getInstanceDetails(instanceInfo.instanceID);
-    //const privateIP = ec2MetaData.privateIP || '';
+
+    /*
+     * queryPrometheusForService returns a mix of instance IDs and bare private
+     * IPs (the 'instance' label is often ip:port, which is stripped to the
+     * bare IP), so membership must be checked against BOTH the instance ID and
+     * the instance's private IP.
+     */
+    const reportsToPrometheus =
+      instanceIPsReportingToPrometheus.includes(instanceInfo.instanceID) ||
+      (!!ec2MetaData.privateIP &&
+        instanceIPsReportingToPrometheus.includes(ec2MetaData.privateIP));
 
     // Check if instance reports to Prometheus and process Prometheus alarm deletion
-    if (instanceIPsReportingToPrometheus.includes(instanceInfo.instanceID)) {
+    if (reportsToPrometheus) {
       prometheusAlarmsToDelete.push({
         instanceID: instanceInfo.instanceID,
         tags: instanceInfo.tags,

--- a/handlers/src/sqs-handler.mts
+++ b/handlers/src/sqs-handler.mts
@@ -43,8 +43,27 @@ async function processRecord(record: SQSRecord): Promise<boolean> {
       .digest('hex')
       .substring(0, 8);
 
+    /*
+     * EC2 messages MUST keep their original MessageGroupId so they remain
+     * strictly serialized on the target FIFO queue. The EC2 path manages AMP
+     * (Amazon Managed Prometheus) rule groups namespaces via a
+     * read-modify-write (DescribeRuleGroupsNamespace -> mutate in memory ->
+     * PutRuleGroupsNamespace), and the AMP API has no conditional put.
+     * Appending the hash suffix lets these messages process concurrently,
+     * which causes lost updates (whole-namespace replaces clobber each other
+     * and silently drop rules). EC2 is the only service using the Prometheus
+     * path; all other services keep the hash suffix for parallelism, which is
+     * safe for them. Message bodies are unchanged, so contentBasedDeduplication
+     * behavior on the target FIFO queue is unaffected.
+     */
+    const originalMessageGroupId = record.attributes.MessageGroupId;
+    const isEc2Message =
+      originalMessageGroupId?.toLowerCase() === 'autoalarm-ec2';
+
     // Create a unique message group ID by appending the hash to the message ID
-    const messageGroupId = `${record.attributes.MessageGroupId}-${messageHash}`;
+    const messageGroupId = isEc2Message
+      ? originalMessageGroupId
+      : `${originalMessageGroupId}-${messageHash}`;
 
     // Log routing details
     log


### PR DESCRIPTION
**PR 6 of 9** from the verified AutoAlarm code review. Focus: reliability of the Amazon Managed Prometheus (AMP) rule-groups-namespace path for EC2 alarms.

## Findings fixed

1. **[CRITICAL] AMP namespace lost-update race** — `handlers/src/sqs-handler.mts`
   Failure: two concurrent EC2 events each Describe → mutate → Put the whole namespace; the second Put clobbers the first and silently drops rules. The hash suffix appended to every forwarded `MessageGroupId` defeated FIFO serialization.
   **Approved decision:** EC2-bound messages (original group id `AutoAlarm-ec2`) now keep their original `MessageGroupId` so they process strictly in order; all other services keep the hash suffix and their parallelism. **Tradeoff:** EC2 events are now processed one-at-a-time on the main queue, reducing EC2 throughput in exchange for correctness of the AMP read-modify-write (the API has no conditional put). Message bodies are unchanged, so `contentBasedDeduplication` behavior is unaffected.

2. **[HIGH] `createNamespace` swallowed create failures** — `handlers/src/alarm-configs/utils/prometheus-tools.mts`
   Failure: a routine `ConflictException` on concurrent create was logged, then "Created new namespace and added rules" was logged anyway → silent loss of all rules. Now rethrows; success log moved into the success path.

3. **[MEDIUM] `batchPromRulesDeletion` swallowed errors after retries** — `prometheus-tools.mts`
   Failure: terminated instances' rules persisted while callers saw success. Now rethrows after logging (callers in `ec2-modules.mts` already have try/catch).

4. **[MEDIUM] `listNamespaces` unbounded retry + missing pagination** — `prometheus-tools.mts`
   Failure: any error (incl. AccessDenied) waited 60s and recursed until Lambda timeout, and `nextToken` was ignored so the 2000-rule guard undercounted. Now paginates via `nextToken`, retries at most 3 attempts with a 5s delay, and rethrows `AccessDeniedException`/`ValidationException` immediately.

5. **[MEDIUM] PromQL instance regex matched longer IPs** — `handlers/src/alarm-configs/utils/prometheus-queries.mts` (all 6 templates)
   Failure: `instance=~"(10\\.0\\.1\\.5.*|i-...)"` also matched `10.0.1.50:9100` → cross-instance alerts. `.*` replaced with an optional port suffix; final PromQL renders as `10\\.0\\.1\\.5(:\\d+)?` (verified: matches `10.0.1.5` and `10.0.1.5:9100`, rejects `10.0.1.50:9100` and `10.0.1.55`).

6. **[MEDIUM] Fallback rule group never attached to namespace** — `prometheus-tools.mts`
   Failure: `find(...) || {name, rules: []}` created a detached object, so all rules added to it were dropped by `yaml.dump(nsDetails)`. The fallback group is now pushed into `nsDetails.groups`.

7. **[MEDIUM] Instance-identity confusion in CloudWatch-vs-Prometheus routing** — `handlers/src/service-modules/ec2-modules.mts`
   Failure: `queryPrometheusForService` returns bare private IPs (port stripped) while comparisons used `.includes(instanceID)` → never matched → wrong alarm routing and orphaned prom rules on termination. Membership is now checked against BOTH the instance ID and the instance's private IP in `manageActiveEC2InstanceAlarms` and `manageInactiveInstanceAlarms` (metadata with `privateIP` was already fetched in both paths; no type changes needed).

8. **[MEDIUM] Fixed 90s sleep after namespace creation** — `prometheus-tools.mts`
   Failure: 90s of billed Lambda time per namespace create; the delete-and-recreate path waited 0s. Both paths now poll `DescribeRuleGroupsNamespace` every 5s until `ACTIVE` (cap 120s, error after cap, fail fast on `CREATION_FAILED`/`UPDATE_FAILED`).

9. **[LOW] Multiplied retry budgets** — `prometheus-tools.mts`
   `AmpClient` retry strategy reduced from `ConfiguredRetryStrategy(20)` to `ConfiguredRetryStrategy(5, attempt => 100 + attempt * 1000)`; `retryWithExponentialBackoff` defaults reduced to `maxRetries=3 / initialDelay=5000 / delayIncrement=5000`. With the poll-based wait (#8), the giant sleeps are no longer needed.

10. **[LOW] Sequential describes + redundant re-describe** — `managePromNamespaceAlarms`
    All namespaces are now described via `Promise.all`, and the target namespace's details are reused from that pass instead of a second Describe call.

## Verification
- `handlers`: `tsc --noEmit` clean, `pnpm run build` (prettier check + eslint + tsc) clean, `vitest` 13/13 passed.
- `cdk`: `pnpm run build` clean.
- Rendered PromQL regex behavior verified with a node script (see finding 5).