### PR TITLE
Fix resource identifier extraction across service modules (PR 2 of 9)

### DIFF
--- a/handlers/src/service-modules/alb-modules.mts
+++ b/handlers/src/service-modules/alb-modules.mts
@@ -209,7 +209,17 @@ export async function manageInactiveALBAlarms(loadBalancerName: string) {
   }
 }
 
-function extractAlbNameFromArn(arn: string): LoadBalancerIdentifiers {
+function extractAlbNameFromArn(
+  arn: string | undefined | null,
+): LoadBalancerIdentifiers {
+  // Classic ELB events carry a loadBalancerName instead of an ARN, so the
+  // input may be undefined. Treat that as an unsupported load balancer.
+  if (!arn) {
+    return {
+      LBType: null,
+      LBName: null,
+    };
+  }
   const regex = /\/(app|net)\/(.*?\/[^/]+)$/;
   const match = arn.match(regex);
   if (!match)
@@ -217,9 +227,11 @@ function extractAlbNameFromArn(arn: string): LoadBalancerIdentifiers {
       LBType: null,
       LBName: null,
     };
+  // The CloudWatch AWS/ApplicationELB LoadBalancer dimension requires the
+  // type prefix (e.g. 'app/my-alb/1234567890abcdef'), so keep it in the name.
   return {
     LBType: match[1] as 'app' | 'net',
-    LBName: match[2],
+    LBName: `${match[1]}/${match[2]}`,
   };
 }
 
@@ -252,7 +264,7 @@ export async function parseALBEventAndCreateAlarms(event: any): Promise<{
       switch (event.detail.eventName) {
         case 'CreateLoadBalancer':
           loadBalancerArn =
-            event.detail.responseElements?.loadBalancers[0]?.loadBalancerArn;
+            event.detail.responseElements?.loadBalancers?.[0]?.loadBalancerArn;
           eventType = 'Create';
           log
             .info()
@@ -309,13 +321,18 @@ export async function parseALBEventAndCreateAlarms(event: any): Promise<{
   }
 
   const loadBalancer = extractAlbNameFromArn(loadBalancerArn);
-  if (loadBalancer.LBType === null) {
+  if (loadBalancer.LBType === null || loadBalancer.LBName === null) {
     log
-      .error()
+      .warn()
       .str('function', 'parseALBEventAndCreateAlarms')
       .str('loadBalancerArn', loadBalancerArn)
       .obj('Load Balancer Identifiers', loadBalancer)
-      .msg('Extracted load balancer name is empty');
+      .msg(
+        'Unable to extract an application or network load balancer name from the event. ' +
+          'This is likely a Classic or Gateway load balancer which AutoAlarm does not support. Skipping processing.',
+      );
+    // return early to avoid processing unsupported load balancers
+    return;
   }
 
   // TODO: we can use this conditional as an entry point to manage nlbs in the future as we build this out.
@@ -323,7 +340,7 @@ export async function parseALBEventAndCreateAlarms(event: any): Promise<{
    *
    * gracefully logging a warning for now if a network load balancer has been tagged.
    */
-  if (loadBalancer.LBType!.includes('net')) {
+  if (loadBalancer.LBType.includes('net')) {
     log
       .warn()
       .str('function', 'parseALBEventAndCreateAlarms')
@@ -352,14 +369,14 @@ export async function parseALBEventAndCreateAlarms(event: any): Promise<{
       .str('function', 'parseALBEventAndCreateAlarms')
       .str('loadBalancerArn', loadBalancerArn)
       .msg('Starting to manage ALB alarms');
-    await manageALBAlarms(loadBalancer.LBName!, tags);
+    await manageALBAlarms(loadBalancer.LBName, tags);
   } else if (eventType === 'Delete') {
     log
       .info()
       .str('function', 'parseALBEventAndCreateAlarms')
       .str('loadBalancerArn', loadBalancerArn)
       .msg('Starting to manage inactive ALB alarms');
-    await manageInactiveALBAlarms(loadBalancer.LBName!);
+    await manageInactiveALBAlarms(loadBalancer.LBName);
   }
 
   return {loadBalancerArn, eventType, tags};

--- a/handlers/src/service-modules/cloudfront-modules.mts
+++ b/handlers/src/service-modules/cloudfront-modules.mts
@@ -221,6 +221,7 @@ export async function parseCloudFrontEventAndCreateAlarms(
   tags: Record<string, string>;
 }> {
   let distributionArn: string = '';
+  let distributionId: string = '';
   let eventType: string = '';
   let tags: Record<string, string> = {};
 
@@ -268,13 +269,15 @@ export async function parseCloudFrontEventAndCreateAlarms(
           break;
 
         case 'DeleteDistribution':
-          distributionArn = event.detail.responseElements?.distribution?.aRN;
+          // DeleteDistribution returns a 204 with no responseElements, so use
+          // the distribution ID from the request parameters directly.
+          distributionId = event.detail.requestParameters?.id;
           eventType = 'Delete';
           log
             .info()
             .str('function', 'parseCloudFrontEventAndCreateAlarms')
             .str('eventType', 'Delete')
-            .str('distributionArn', distributionArn)
+            .str('distributionId', distributionId)
             .str('requestId', event.detail.requestID)
             .msg('Processing DeleteDistribution event');
           break;
@@ -297,14 +300,23 @@ export async function parseCloudFrontEventAndCreateAlarms(
         .msg('Unexpected event type');
   }
 
-  // Extract the distribution ID from the ARN
-  const distributionId = extractDistributionIdFromArn(distributionArn);
+  // Extract the distribution ID from the ARN (Delete events set it directly
+  // from the request parameters since the API response carries no ARN)
+  if (!distributionId) {
+    distributionId = extractDistributionIdFromArn(distributionArn ?? '');
+  }
   if (!distributionId) {
     log
       .error()
       .str('function', 'parseCloudFrontEventAndCreateAlarms')
       .str('distributionArn', distributionArn)
-      .msg('Extracted CloudFront distribution ID is empty');
+      .str('eventType', eventType)
+      .msg(
+        'Resolved CloudFront distribution ID is empty. Aborting alarm management.',
+      );
+    throw new Error(
+      'Resolved CloudFront distribution ID is empty. Aborting alarm management.',
+    );
   }
 
   log

--- a/handlers/src/service-modules/opensearch-modules.mts
+++ b/handlers/src/service-modules/opensearch-modules.mts
@@ -222,6 +222,7 @@ export async function parseOSEventAndCreateAlarms(event: any): Promise<{
   tags: Record<string, string>;
 }> {
   let domainArn: string = '';
+  let domainName: string = '';
   let eventType: string = '';
   let tags: Record<string, string> = {};
 
@@ -269,13 +270,15 @@ export async function parseOSEventAndCreateAlarms(event: any): Promise<{
           break;
 
         case 'DeleteDomain':
-          domainArn = event.detail.requestParameters?.domainArn;
+          // DeleteDomain request parameters carry the domain name, not an ARN.
+          // The domain name is the alarm key and CloudWatch dimension value.
+          domainName = event.detail.requestParameters?.domainName;
           eventType = 'Delete';
           log
             .info()
             .str('function', 'parseOSEventAndCreateAlarms')
             .str('eventType', 'Delete')
-            .str('domainArn', domainArn)
+            .str('domainName', domainName)
             .str('requestId', event.detail.requestID)
             .msg('Processing DeleteDomain event');
           break;
@@ -298,14 +301,29 @@ export async function parseOSEventAndCreateAlarms(event: any): Promise<{
         .msg('Unexpected event type');
   }
 
-  const domainName = extractOSDomainNameFromArn(domainArn);
-  const accountID = extractAccountIdFromArn(domainArn);
+  // Delete events set the domain name directly from the request parameters;
+  // all other events extract it from the domain ARN.
+  if (!domainName) {
+    domainName = extractOSDomainNameFromArn(domainArn ?? '');
+  }
+  // The account ID is carried on the event itself, so derive it from there
+  // rather than from the ARN (which Delete events do not carry).
+  const accountID =
+    event.account ||
+    event.detail?.recipientAccountId ||
+    extractAccountIdFromArn(domainArn ?? '');
   if (!domainName) {
     log
       .error()
       .str('function', 'parseOSEventAndCreateAlarms')
       .str('domainArn', domainArn)
-      .msg('Extracted domain name is empty');
+      .str('eventType', eventType)
+      .msg(
+        'Resolved OpenSearch domain name is empty. Aborting alarm management.',
+      );
+    throw new Error(
+      'Resolved OpenSearch domain name is empty. Aborting alarm management.',
+    );
   }
 
   log

--- a/handlers/src/service-modules/rds-cluster-modules.mts
+++ b/handlers/src/service-modules/rds-cluster-modules.mts
@@ -285,7 +285,10 @@ function findRDSClusterArn(eventObj: Record<string, any>): string {
 
 // On occasion AWS will splice the arn with the resource ID. If this happens, we need to remap the arn from the resource ID.
 async function getARNFromResourceId(arn: string) {
-  if (!arn.includes('cluster:cluster-')) return arn;
+  // Only treat the ARN as a DBCluster resource-ID form when the final segment
+  // looks like a real resource ID (e.g. 'cluster-ABCDE12345FGHIJ67890KLMNO1').
+  // A cluster literally named 'cluster-prod' must be treated as a normal name ARN.
+  if (!/:cluster:cluster-[A-Z0-9]{10,}$/.test(arn)) return arn;
 
   const resourceId = arn.split(':').at(-1); // grab the last index which is the resource ID
 

--- a/handlers/src/service-modules/route53-resolver-modules.mts
+++ b/handlers/src/service-modules/route53-resolver-modules.mts
@@ -203,6 +203,22 @@ function extractR53ResolverNameFromArn(arn: string): string {
   return match ? match[1] : '';
 }
 
+/**
+ * Builds the full resolver endpoint ARN from a bare endpoint ID using the
+ * region and account ID carried on the CloudTrail event detail. The
+ * ListTagsForResource API requires an ARN, but CloudTrail events only carry
+ * the bare 'rslvr-...' endpoint ID.
+ */
+function buildR53ResolverArn(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  event: any,
+  endpointId: string,
+): string {
+  const eventRegion = event.detail?.awsRegion || event.region || region;
+  const accountId = event.detail?.recipientAccountId || event.account || '';
+  return `arn:aws:route53resolver:${eventRegion}:${accountId}:resolver-endpoint/${endpointId}`;
+}
+
 export async function parseR53ResolverEventAndCreateAlarms(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   event: any,
@@ -242,7 +258,11 @@ export async function parseR53ResolverEventAndCreateAlarms(
             .str('requestId', event.detail.requestID)
             .msg('Processing CreateResolverEndpoint event');
           if (endpointId) {
-            tags = await fetchR53ResolverTags(endpointId);
+            // ListTagsForResource requires an ARN, but the CloudTrail event
+            // only carries the bare endpoint ID. Build the ARN from the event.
+            tags = await fetchR53ResolverTags(
+              buildR53ResolverArn(event, endpointId),
+            );
             log
               .info()
               .str('function', 'parseR53ResolverEventAndCreateAlarms')
@@ -288,14 +308,23 @@ export async function parseR53ResolverEventAndCreateAlarms(
         .msg('Unexpected event type');
   }
 
-  // Extract the Resolver name from the ARN
-  const resolverName = extractR53ResolverNameFromArn(endpointId);
+  // Resolve the endpoint identifier. CloudTrail events carry a bare
+  // 'rslvr-...' endpoint ID while Tag Change events carry the full ARN.
+  const resolverName = endpointId?.startsWith('rslvr-')
+    ? endpointId
+    : extractR53ResolverNameFromArn(endpointId ?? '');
   if (!resolverName) {
     log
       .error()
       .str('function', 'parseR53ResolverEventAndCreateAlarms')
       .str('endpointId', endpointId)
-      .msg('Extracted Route 53 Resolver name is empty');
+      .str('eventType', eventType)
+      .msg(
+        'Resolved Route 53 Resolver endpoint identifier is empty. Aborting to avoid acting on all R53R alarms.',
+      );
+    throw new Error(
+      'Resolved Route 53 Resolver endpoint identifier is empty. Aborting to avoid acting on all R53R alarms.',
+    );
   }
 
   log

--- a/handlers/src/service-modules/sqs-modules.mts
+++ b/handlers/src/service-modules/sqs-modules.mts
@@ -186,14 +186,6 @@ export async function manageInactiveSQSAlarms(queueUrl: string) {
 }
 
 function extractQueueName(queueUrl: string): string {
-  const parts = queueUrl.split('/');
-  log
-    .debug()
-    .str('function', 'extractQueueName')
-    .str('queueUrl', queueUrl)
-    .str('parts', JSON.stringify(parts))
-    .str('queueName', parts.at(-1)!)
-    .msg('Extracted queue name');
   if (!queueUrl) {
     log
       .error()
@@ -202,6 +194,14 @@ function extractQueueName(queueUrl: string): string {
       .msg('Invalid queue URL: Queue name not found');
     throw new Error('Invalid queue URL: Queue name not found');
   }
+  const parts = queueUrl.split('/');
+  log
+    .debug()
+    .str('function', 'extractQueueName')
+    .str('queueUrl', queueUrl)
+    .str('parts', JSON.stringify(parts))
+    .str('queueName', parts.at(-1)!)
+    .msg('Extracted queue name');
   return parts.at(-1)!;
 }
 

--- a/handlers/src/service-modules/step-function-modules.mts
+++ b/handlers/src/service-modules/step-function-modules.mts
@@ -213,55 +213,6 @@ export async function manageInactiveSFNAlarms(sfnArn: string): Promise<void> {
   }
 }
 
-/**
- * Searches the provided object for the first occurrence of an RDS ARN.
- * Serializes the object to a JSON string, looks for the substring "arn:aws:rds",
- * and then extracts everything up to the next quotation mark.
- * Logs an error and returns an empty string if no valid RDS ARN can be found.
- *
- * @param {Record<string, any>} eventObj - A JSON-serializable object to search for an RDS ARN.
- * @returns {string} The extracted RDS ARN, or an empty string if not found.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function findSFNArn(eventObj: Record<string, any>): string {
-  const eventString = JSON.stringify(eventObj);
-
-  // 1) Find where the ARN starts.
-  const startIndex = eventString.indexOf('arn:aws:states');
-  if (startIndex === -1) {
-    log
-      .error()
-      .str('function', 'findSFNArn')
-      .obj('eventObj', eventObj)
-      .msg('No SFN ARN found in event');
-    return '';
-  }
-
-  // 2) Find the next quote after that.
-  const endIndex = eventString.indexOf('"', startIndex);
-  if (endIndex === -1) {
-    log
-      .error()
-      .str('function', 'findSFNArn')
-      .obj('eventObj', eventObj)
-      .msg('No ending quote found for SFN ARN');
-    return '';
-  }
-
-  // 3) Extract the ARN
-  const arn = eventString.substring(startIndex, endIndex);
-
-  log
-    .info()
-    .str('function', 'findSFNArn')
-    .str('arn', arn)
-    .str('startIndex', startIndex.toString())
-    .str('endIndex', endIndex.toString())
-    .msg('Extracted SFN ARN');
-
-  return arn;
-}
-
 export async function parseSFNEventAndCreateAlarms(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   event: Record<string, any>,
@@ -270,13 +221,13 @@ export async function parseSFNEventAndCreateAlarms(
   eventType: string;
   tags: Record<string, string>;
 } | void> {
-  let sfnArn: string | Error = '';
+  let sfnArn: string = '';
   let eventType: string = '';
   let tags: Record<string, string> = {};
 
   switch (event['detail-type']) {
     case 'Tag Change on Resource':
-      sfnArn = findSFNArn(event);
+      sfnArn = event.resources?.[0] ?? '';
       if (!sfnArn) {
         log
           .error()
@@ -316,7 +267,10 @@ export async function parseSFNEventAndCreateAlarms(
     case 'AWS API Call via CloudTrail':
       switch (event.detail.eventName) {
         case 'CreateStateMachine':
-          sfnArn = findSFNArn(event);
+          // Read the ARN from the structured response rather than string-mining
+          // the event, which can match service-integration ARNs (e.g.
+          // 'arn:aws:states:::lambda:invoke') inside the state machine definition.
+          sfnArn = event.detail.responseElements?.stateMachineArn ?? '';
           if (!sfnArn) {
             log
               .error()
@@ -354,7 +308,7 @@ export async function parseSFNEventAndCreateAlarms(
           break;
 
         case 'DeleteStateMachine':
-          sfnArn = findSFNArn(event);
+          sfnArn = event.detail.requestParameters?.stateMachineArn ?? '';
           if (!sfnArn) {
             log
               .error()


### PR DESCRIPTION
PR 2 of 9 from the AutoAlarm code review. Fixes resource identifier extraction bugs in service modules that caused mass alarm deletion, alarms watching nonexistent metrics, and Lambda crashes.

## Findings fixed

1. **[CRITICAL] `handlers/src/service-modules/route53-resolver-modules.mts`** — CloudTrail Create/Delete events carry a bare `rslvr-...` endpoint ID, but the identifier was always run through ARN extraction, yielding `''`. An empty identifier flowed into `deleteExistingAlarms('R53R', '')` (prefix `AutoAlarm-R53R-`), **deleting every R53R alarm in the region** on any endpoint create/delete. Bare IDs are now used directly as the identifier; ARN extraction only runs on ARNs. Also, `fetchR53ResolverTags` was called with the bare ID while `ListTagsForResource` requires an ARN (always failed, silently returning `{}`) — the ARN is now built from the event's `awsRegion`/`recipientAccountId`. An empty resolved identifier now logs and throws instead of proceeding.

2. **[CRITICAL] `handlers/src/service-modules/alb-modules.mts`** — `extractAlbNameFromArn` captured the name *after* the `app/` prefix (`my-alb/hash`), but the `AWS/ApplicationELB` `LoadBalancer` dimension requires `app/my-alb/hash` (as sibling `targetgroup-modules.mts` correctly does). **Every ALB alarm watched a nonexistent metric and could never fire.** The type prefix is now included in the extracted name.
   **Migration note:** this changes ALB alarm names from `AutoAlarm-ALB-my-alb/hash-...` to `AutoAlarm-ALB-app/my-alb/hash-...`. Create/delete round-trips are self-consistent under the new name; existing (broken) alarms are superseded and stale ones are cleaned up by reconciliation on the next event for each load balancer.

3. **[HIGH] `alb-modules.mts` null-safety** — (a) missing optional chain after `loadBalancers` crashed on Classic-ELB `CreateLoadBalancer` (no `loadBalancers` array); (b) Classic `DeleteLoadBalancer` carries `loadBalancerName`, not `loadBalancerArn`, so `extractAlbNameFromArn(undefined)` threw; (c) the LBType null-check only logged and fell through to `loadBalancer.LBType!.includes('net')`, throwing on gateway LBs / unmatched ARNs. Now: optional chaining added, `extractAlbNameFromArn` handles null/undefined input, and unsupported (Classic/Gateway) load balancers are skipped with a structured warning instead of crashing.

4. **[HIGH] `handlers/src/service-modules/cloudfront-modules.mts`** — `DeleteDistribution` returns HTTP 204 with no `responseElements`, so reading `responseElements?.distribution?.aRN` produced `undefined` and `extractDistributionIdFromArn(undefined)` threw. Delete now uses `requestParameters.id` directly; Create keeps ARN extraction. An empty resolved ID now logs and throws.

5. **[HIGH] `handlers/src/service-modules/step-function-modules.mts`** — `findSFNArn` took the *first* `arn:aws:states` occurrence in `JSON.stringify(event)`; for `CreateStateMachine` that's a service-integration resource inside the state machine definition (e.g. `arn:aws:states:::lambda:invoke`), truncated at an escaped quote — a garbage ARN, so `fetchSFNTags` failed silently and **no alarms were created for new state machines**. String-mining is removed; the ARN is read from the structured event (`event.resources[0]` for tag changes, `responseElements.stateMachineArn` for Create, `requestParameters.stateMachineArn` for Delete), with existing falsy guards retained. Exported function signature unchanged.

6. **[MEDIUM] `handlers/src/service-modules/opensearch-modules.mts`** — `DeleteDomain` does not carry `requestParameters.domainArn`, so ARN extraction threw on `undefined`. Delete now uses `requestParameters.domainName` directly (the domain name is the alarm key and CloudWatch dimension); the account ID is derived from the event (`account`/`recipientAccountId`) with ARN extraction as fallback. An empty resolved domain name now logs and throws.
   **Dependency note:** PR 1 fixes the CDK EventBridge rule so OpenSearch delete events actually reach this handler; this fix makes them processed correctly once they arrive.

7. **[MEDIUM] `handlers/src/service-modules/rds-cluster-modules.mts`** — `getARNFromResourceId` treated any ARN containing `cluster:cluster-` as the resource-ID form, so a cluster literally *named* `cluster-prod` false-positived, `DescribeDBClusters` found nothing, and every event for that cluster threw forever. Detection now requires a genuine DBCluster resource ID shape (`/:cluster:cluster-[A-Z0-9]{10,}$/`); the DescribeDBClusters fallback and throw-on-lookup-failure behavior are unchanged.

8. **[LOW] `handlers/src/service-modules/sqs-modules.mts`** — `extractQueueName` dereferenced `queueUrl.split('/')` before its `!queueUrl` guard, producing a raw TypeError instead of the structured error. The guard now runs first.

## Relationship to sibling PRs

- Independent of PR 1 (TGW/VPN routing) and PR 3 (alarm-tools empty-identifier guards / exact-name deletion); merges standalone off `develop`. The falsy-identifier guards here are intentionally local to the service modules and complement PR 3's defenses in alarm-tools.

## Verification

- `handlers`: `tsc --noEmit` clean, `eslint .` clean, `prettier` applied, `vitest` 13/13 passing.
- `cdk`: `pnpm run build` clean, tests passing.