### PR TITLE
Fix ReAlarm reliability: idempotent rule cleanup, correct failure attribution, throttle detection, bounded producer concurrency, scoped SetAlarmState

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,10 @@ Empty positions between slashes (`//`) preserve the default values for those par
 The ReAlarm function is an AWS Lambda-based handler designed to monitor and reset CloudWatch alarms that are in an
 "ALARM" state. It is an optional part of the AutoAlarm system, aimed at ensuring alarms are not missed or ignored.
 
+> **Important:** By default, ReAlarm resets **every** CloudWatch alarm in the account that is in `ALARM` state — not
+> only AutoAlarm-managed alarms. Individual alarms can opt out by setting the `autoalarm:re-alarm-enabled=false` tag.
+> Alarms with AutoScaling actions are excluded automatically.
+
 ### Default Values
 
 By default, the ReAlarm function is enabled. When ReAlarm is enabled, it runs on a default schedule of every 120 minutes.
@@ -414,6 +418,8 @@ ReAlarm's behavior can be configured on a per-alarm basis using tags.
     - The ReAlarm schedule by default runs every 120 minutes.
     - ReAlarm can be customized to run at different intervals on a per-alarm basis by setting the `autoalarm:re-alarm-minutes`
       tag to a whole number value.
+    - The value must be between **5** and **1440** (one day) minutes, inclusive. Values outside these bounds are
+      treated as invalid and any existing per-alarm schedule is removed.
 - **Disable ReAlarm for a Resource**:
     - Alarms can be tagged with `autoalarm:re-alarm-enabled=false` to exclude them from the ReAlarm process.
     - When this tag is present on an alarm, ReAlarm will skip resetting it, regardless of its state.

--- a/cdk/lib/realarm-consumer-subconstruct.ts
+++ b/cdk/lib/realarm-consumer-subconstruct.ts
@@ -8,7 +8,7 @@ import {
 } from 'aws-cdk-lib/aws-iam';
 import {Construct} from 'constructs';
 import * as path from 'path';
-import {Duration} from 'aws-cdk-lib';
+import {ArnFormat, Duration, Stack} from 'aws-cdk-lib';
 import {Architecture} from 'aws-cdk-lib/aws-lambda';
 import {SqsEventSource} from 'aws-cdk-lib/aws-lambda-event-sources';
 import {NoBreachingExtendedQueue} from './extended-libs-subconstruct';
@@ -105,12 +105,31 @@ export class ReAlarmConsumer extends Construct {
       description: 'Execution role for ReAlarm Consumer Lambda function',
     });
 
+    // ReAlarm intentionally operates on every alarm in the account (opt-out
+    // via the autoalarm:re-alarm-enabled=false tag), but SetAlarmState can
+    // still be scoped to alarm ARNs in this account/region rather than '*'.
+    reAlarmConsumerRole.addToPolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['cloudwatch:SetAlarmState'],
+        resources: [
+          Stack.of(this).formatArn({
+            service: 'cloudwatch',
+            resource: 'alarm',
+            resourceName: '*',
+            arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+          }),
+        ],
+      }),
+    );
+
+    // DescribeAlarms and ListTagsForResource are read/list operations that
+    // must run against all alarms in the account.
     reAlarmConsumerRole.addToPolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
         actions: [
           'cloudwatch:DescribeAlarms',
-          'cloudwatch:SetAlarmState',
           'cloudwatch:ListTagsForResource',
         ],
         resources: ['*'],

--- a/handlers/src/realarm-consumer-handler.mts
+++ b/handlers/src/realarm-consumer-handler.mts
@@ -14,7 +14,12 @@ import {
 import * as logging from '@nr1e/logging';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 
-const retryStrategy = new ConfiguredRetryStrategy(20);
+// Retry up to 5 times with linear backoff (100ms + 1s per attempt) instead of
+// hammering the API with constant-delay retries.
+const retryStrategy = new ConfiguredRetryStrategy(
+  5,
+  (attempt) => 100 + attempt * 1000,
+);
 const cloudwatch = new CloudWatchClient({
   region: process.env.AWS_REGION,
   retryStrategy: retryStrategy,
@@ -35,11 +40,24 @@ const log = logging.initialize({
 const TAG_RETRY_ATTEMPTS = 3;
 const DELAY_BETWEEN_OPERATIONS = 200;
 const THROTTLING_ERROR_CODES = [
+  'Throttling', // CloudWatch (Query protocol) throttle error name
   'ThrottlingException',
   'RequestLimitExceeded',
   'TooManyRequestsException',
+  'RequestThrottled', // SQS throttle error name
 ];
 const BACKOFF_MULTIPLIER = 1.5;
+
+/**
+ * Detects throttling errors by matching the error name (precise) and falling
+ * back to a message substring match for wrapped/stringified errors.
+ */
+function isThrottlingError(error: unknown): boolean {
+  const errorName = error instanceof Error ? error.name : '';
+  return THROTTLING_ERROR_CODES.some(
+    (code) => errorName === code || String(error).includes(code),
+  );
+}
 const MAX_CONCURRENT_TAG_REQUESTS = 5;
 const TAG_REQUEST_DELAY = 200; // 200ms between requests
 
@@ -107,7 +125,7 @@ async function fetchTagsWithRetry(
       }
       return tagsResponse.Tags;
     } catch (error) {
-      if (THROTTLING_ERROR_CODES.some((code) => String(error).includes(code))) {
+      if (isThrottlingError(error)) {
         metrics.throttlingErrors++;
       }
 
@@ -145,10 +163,12 @@ function chunk<T>(array: T[], size: number): T[][] {
 }
 
 // Create a rate limiter utility
-async function rateLimitedTagFetch(
-  alarms: AlarmMessage[],
-): Promise<Map<string, Tag[]>> {
+async function rateLimitedTagFetch(alarms: AlarmMessage[]): Promise<{
+  tagResults: Map<string, Tag[]>;
+  failedArns: Set<string>;
+}> {
   const tagResults = new Map<string, Tag[]>();
+  const failedArns = new Set<string>();
 
   // Process alarms in smaller chunks
   const chunks = chunk(alarms, MAX_CONCURRENT_TAG_REQUESTS);
@@ -160,6 +180,10 @@ async function rateLimitedTagFetch(
         const tags = await fetchTagsWithRetry(alarm);
         tagResults.set(alarm.alarmArn, tags);
       } catch (error) {
+        // Track the failure - without tags we cannot honor opt-outs like
+        // autoalarm:re-alarm-enabled=false, so the caller must not process
+        // this alarm with an empty tag set.
+        failedArns.add(alarm.alarmArn);
         log
           .error()
           .str('function', 'rateLimitedTagFetch')
@@ -175,7 +199,7 @@ async function rateLimitedTagFetch(
     await Promise.all(chunkPromises);
   }
 
-  return tagResults;
+  return {tagResults, failedArns};
 }
 
 function validateAlarm(alarm: AlarmMessage, tags: Tag[]): boolean {
@@ -188,10 +212,16 @@ function validateAlarm(alarm: AlarmMessage, tags: Tag[]): boolean {
     .str('actions', JSON.stringify(alarm.alarmActions))
     .msg('Alarm actions found');
 
-  // If there are autoscaling actions, log them specifically
-  const autoscalingActions = alarm.alarmActions.filter((action) =>
-    action.includes('autoscaling'),
-  );
+  // If there are autoscaling actions, log them specifically.
+  // Match on the ARN service segment (arn:aws:<service>:...) rather than a
+  // substring of the whole ARN so that e.g. an SNS topic named
+  // "my-autoscaling-alerts" does not exclude its alarm. EC2 Auto Scaling
+  // policies use the 'autoscaling' service; Application Auto Scaling uses
+  // 'application-autoscaling'.
+  const autoscalingActions = alarm.alarmActions.filter((action) => {
+    const service = action.split(':')[2];
+    return service === 'autoscaling' || service === 'application-autoscaling';
+  });
   if (autoscalingActions.length > 0) {
     log
       .info()
@@ -206,10 +236,16 @@ function validateAlarm(alarm: AlarmMessage, tags: Tag[]): boolean {
     (tag) => tag.Key === 'autoalarm:re-alarm-enabled' && tag.Value === 'false',
   );
 
-  const reAlarmOverrideTag = tags.some(
-    (tag) =>
-      tag.Key === 'autoalarm:re-alarm-minutes' && !isNaN(Number(tag.Value)),
-  );
+  // Only a real positive integer counts as an override (mirrors the tag-event
+  // handler). Number('') === 0, so a bare !isNaN check would treat ''/' '/'0'
+  // as an override and exclude the alarm from BOTH re-alarm paths.
+  const reAlarmOverrideTag = tags.some((tag) => {
+    if (tag.Key !== 'autoalarm:re-alarm-minutes') {
+      return false;
+    }
+    const minutes = Number(tag.Value);
+    return Number.isInteger(minutes) && minutes > 0;
+  });
 
   const hasAutoScalingAction = autoscalingActions.length > 0;
 
@@ -265,7 +301,7 @@ async function resetAlarmState(
       .msg(`Successfully reset alarm: ${alarmName}`);
   } catch (error) {
     metrics.totalErrors++;
-    if (THROTTLING_ERROR_CODES.some((code) => String(error).includes(code))) {
+    if (isThrottlingError(error)) {
       metrics.throttlingErrors++;
     }
 
@@ -338,7 +374,7 @@ async function processAlarm(message: AlarmMessage, tags: Tag[]): Promise<void> {
       await delay(currentDelay);
     } catch (error) {
       // Handle errors from the API calls
-      if (THROTTLING_ERROR_CODES.some((code) => String(error).includes(code))) {
+      if (isThrottlingError(error)) {
         throttleCount++;
         currentDelay = Math.min(currentDelay * BACKOFF_MULTIPLIER, 2000);
         log
@@ -381,7 +417,9 @@ export const handler: SQSHandler = async (
   const batchItemFailures: SQSBatchItemFailure[] = [];
   const batchItemBodies: SQSRecord[] = [];
 
-  const messages = event.Records.map((record) => {
+  // Keep the link between each parsed message and its originating SQS record
+  // so failures can be attributed to the correct messageId.
+  const parsedMessages = event.Records.flatMap((record) => {
     try {
       // Check if the record body contains an error message
       if (record.body && record.body.includes('errorMessage')) {
@@ -389,9 +427,9 @@ export const handler: SQSHandler = async (
           .warn()
           .str('messageId', record.messageId)
           .msg('Error message found in record body');
-        return null;
+        return [];
       }
-      return JSON.parse(record.body) as AlarmMessage;
+      return [{record, message: JSON.parse(record.body) as AlarmMessage}];
     } catch (error) {
       log
         .error()
@@ -400,38 +438,50 @@ export const handler: SQSHandler = async (
         .msg('Error parsing record body');
       batchItemFailures.push({itemIdentifier: record.messageId});
       batchItemBodies.push(record);
-      return null;
+      return [];
     }
-  }).filter((message): message is AlarmMessage => message !== null);
+  });
 
   // Fetch all tags upfront
-  const tagCache = await rateLimitedTagFetch(messages);
+  const {tagResults: tagCache, failedArns} = await rateLimitedTagFetch(
+    parsedMessages.map(({message}) => message),
+  );
+
+  // Do not process alarms whose tag fetch failed - without tags we cannot
+  // honor opt-outs (autoalarm:re-alarm-enabled=false). Report them as batch
+  // item failures so SQS retries them.
+  const processableMessages = parsedMessages.filter(({record, message}) => {
+    if (failedArns.has(message.alarmArn)) {
+      log
+        .warn()
+        .str('function', 'handler')
+        .str('messageId', record.messageId)
+        .str('alarmName', message.alarmName)
+        .msg(
+          'Skipping alarm because tag fetch failed - reporting for SQS retry',
+        );
+      batchItemFailures.push({itemIdentifier: record.messageId});
+      batchItemBodies.push(record);
+      return false;
+    }
+    return true;
+  });
 
   try {
     // Process messages using cached tags
     const processingResults = await Promise.allSettled(
-      messages.map((message) =>
+      processableMessages.map(({message}) =>
         processAlarm(message, tagCache.get(message.alarmArn) || []),
       ),
     );
 
+    // Attribute failures by index - processingResults[i] corresponds to
+    // processableMessages[i], which carries its originating SQS record.
     const failures = processingResults.filter((result, index) => {
       if (result.status === 'rejected') {
-        // Find the corresponding record ID for this failed message
-        const failedMessage = messages[index];
-        const failedRecordId = event.Records.find(
-          (r) => r.body && r.body.includes(failedMessage.alarmName),
-        )?.messageId;
-
-        if (failedRecordId) {
-          batchItemFailures.push({itemIdentifier: failedRecordId});
-          const record = event.Records.find(
-            (r) => r.messageId === failedRecordId,
-          );
-          if (record) {
-            batchItemBodies.push(record);
-          }
-        }
+        const {record} = processableMessages[index];
+        batchItemFailures.push({itemIdentifier: record.messageId});
+        batchItemBodies.push(record);
         return true;
       }
       return false;

--- a/handlers/src/realarm-producer-handler.mts
+++ b/handlers/src/realarm-producer-handler.mts
@@ -14,12 +14,20 @@ import * as logging from '@nr1e/logging';
 import * as crypto from 'crypto';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 
-const retryStrategy = new ConfiguredRetryStrategy(20);
+// Retry up to 5 times with linear backoff (100ms + 1s per attempt) instead of
+// hammering the API with constant-delay retries.
+const retryStrategy = new ConfiguredRetryStrategy(
+  5,
+  (attempt) => 100 + attempt * 1000,
+);
 const cloudwatch = new CloudWatchClient({
   region: process.env.AWS_REGION,
   retryStrategy: retryStrategy,
 });
-const sqs = new SQSClient({region: process.env.AWS_REGION});
+const sqs = new SQSClient({
+  region: process.env.AWS_REGION,
+  retryStrategy: retryStrategy,
+});
 
 // Set up logging configuration with fallback to 'trace' level
 const level = process.env.LOG_LEVEL || 'trace';
@@ -32,15 +40,31 @@ const log = logging.initialize({
   level,
 });
 
-const DELAY_BETWEEN_BATCHES = 1000;
 const PAGE_SIZE = 100;
 const SQS_BATCH_SIZE = 10;
+// Number of SendMessageBatch calls issued concurrently per group
+const MAX_CONCURRENT_SQS_BATCHES = 5;
+// Small fixed pause between concurrent groups to smooth burst traffic to SQS;
+// throttling itself is handled by the SDK retry strategy.
+const DELAY_BETWEEN_BATCH_GROUPS = 100;
 const THROTTLING_ERROR_CODES = [
+  'Throttling', // CloudWatch (Query protocol) throttle error name
   'ThrottlingException',
   'RequestLimitExceeded',
   'TooManyRequestsException',
+  'RequestThrottled', // SQS throttle error name
 ];
-const BACKOFF_MULTIPLIER = 1.5;
+
+/**
+ * Detects throttling errors by matching the error name (precise) and falling
+ * back to a message substring match for wrapped/stringified errors.
+ */
+function isThrottlingError(error: unknown): boolean {
+  const errorName = error instanceof Error ? error.name : '';
+  return THROTTLING_ERROR_CODES.some(
+    (code) => errorName === code || String(error).includes(code),
+  );
+}
 
 interface ErrorMetrics {
   throttlingErrors: number;
@@ -165,7 +189,6 @@ async function sendAlarmsToSQS(
 
   // Process alarms in batches for efficiency
   const batches = chunk(alarmsToProcess, SQS_BATCH_SIZE);
-  let currentDelay = DELAY_BETWEEN_BATCHES;
 
   log
     .info()
@@ -176,75 +199,43 @@ async function sendAlarmsToSQS(
     .str('isOverride', String(isOverride))
     .msg('Starting to send alarms to SQS');
 
-  // Process each batch of alarms
-  for (const [batchIndex, batch] of batches.entries()) {
-    const startTime = Date.now();
-    let batchThrottleCount = 0;
+  // Create hash for unique message id
+  const messageHash = (alarm: string): string => {
+    return crypto
+      .createHash('sha256')
+      .update(alarm)
+      .digest('hex')
+      .substring(0, 8);
+  };
 
-    // Create hash for unique message id
-    const messageHash = (alarm: string): string => {
-      return crypto
-        .createHash('sha256')
-        .update(alarm)
-        .digest('hex')
-        .substring(0, 8);
-    };
+  const sendBatch = async (
+    batch: MetricAlarm[],
+    batchIndex: number,
+  ): Promise<void> => {
+    // Prepare messages for the batch
+    const entries: SendMessageBatchRequestEntry[] = batch.map((alarm, i) => ({
+      Id: `${batchIndex}-${i}`,
+      MessageBody: JSON.stringify({
+        alarmName: alarm.AlarmName,
+        alarmArn: alarm.AlarmArn,
+        alarmActions: alarm.AlarmActions || [],
+        isOverride,
+      }),
+      MessageGroupId: `realarm-producer-${messageHash(`${alarm.AlarmName}${alarm.AlarmArn}${alarm.AlarmActions}${isOverride}-${i}`)}`,
+    }));
 
     try {
-      // Prepare messages for the batch
-      const entries: SendMessageBatchRequestEntry[] = batch.map((alarm, i) => ({
-        Id: `${batchIndex}-${i}`,
-        MessageBody: JSON.stringify({
-          alarmName: alarm.AlarmName,
-          alarmArn: alarm.AlarmArn,
-          alarmActions: alarm.AlarmActions || [],
-          isOverride,
-        }),
-        MessageGroupId: `realarm-producer-${messageHash(`${alarm.AlarmName}${alarm.AlarmArn}${alarm.AlarmActions}${isOverride}-${i}`)}`,
-      }));
-
-      // Send the batch to SQS
-      const command = new SendMessageBatchCommand({
-        QueueUrl: queueUrl,
-        Entries: entries,
-      });
-
       metrics.totalCalls++;
-      await sqs.send(command);
-
-      const processingTime = Date.now() - startTime;
-
-      // Adjust delay based on throttling and processing time
-      if (batchThrottleCount > 0) {
-        currentDelay = Math.min(currentDelay * BACKOFF_MULTIPLIER, 2000);
-        log
-          .warn()
-          .str('function', 'sendAlarmsToSQS')
-          .num('batchIndex', batchIndex)
-          .num('throttleCount', batchThrottleCount)
-          .num('newDelay', currentDelay)
-          .msg('Increasing delay due to throttling');
-      } else if (processingTime < currentDelay / 2) {
-        currentDelay = Math.max(
-          currentDelay / BACKOFF_MULTIPLIER,
-          DELAY_BETWEEN_BATCHES,
-        );
-        log
-          .info()
-          .str('function', 'sendAlarmsToSQS')
-          .num('batchIndex', batchIndex)
-          .num('processingTime', processingTime)
-          .num('newDelay', currentDelay)
-          .msg('Decreasing delay due to good performance');
-      }
-
-      // Wait before processing next batch
-      await delay(currentDelay);
+      await sqs.send(
+        new SendMessageBatchCommand({
+          QueueUrl: queueUrl,
+          Entries: entries,
+        }),
+      );
     } catch (error) {
       metrics.totalErrors++;
-      if (THROTTLING_ERROR_CODES.some((code) => String(error).includes(code))) {
+      if (isThrottlingError(error)) {
         metrics.throttlingErrors++;
-        batchThrottleCount++;
       }
 
       log
@@ -254,6 +245,20 @@ async function sendAlarmsToSQS(
         .str('error', String(error))
         .msg('Failed to send batch to SQS');
       throw error;
+    }
+  };
+
+  // Send batches with bounded concurrency. Throttling is handled by the SDK
+  // retry strategy (backoff), so no adaptive inter-batch delay is needed -
+  // just a small fixed pause between groups to avoid bursting the SQS API.
+  const indexedBatches = batches.map((batch, index) => ({batch, index}));
+  const batchGroups = chunk(indexedBatches, MAX_CONCURRENT_SQS_BATCHES);
+
+  for (const [groupIndex, group] of batchGroups.entries()) {
+    await Promise.all(group.map(({batch, index}) => sendBatch(batch, index)));
+
+    if (groupIndex < batchGroups.length - 1) {
+      await delay(DELAY_BETWEEN_BATCH_GROUPS);
     }
   }
 }

--- a/handlers/src/realarm-tag-event-handler.mts
+++ b/handlers/src/realarm-tag-event-handler.mts
@@ -34,6 +34,12 @@ const log = logging.initialize({
 // Configuration constants
 const TAG_KEY = 'autoalarm:re-alarm-minutes';
 
+// Bounds for the autoalarm:re-alarm-minutes tag value. The producer scans every
+// alarm in the account on each invocation, so very short schedules are abusive;
+// cap at one day to keep override schedules sane.
+const MIN_REALARM_MINUTES = 5;
+const MAX_REALARM_MINUTES = 1440;
+
 const targetFunctionArn = process.env.PRODUCER_FUNCTION_ARN;
 
 // Initialize AWS service clients
@@ -93,6 +99,18 @@ async function deleteEventBridgeRule(alarmName: string): Promise<void> {
       .str('ruleName', ruleName)
       .msg('Successfully deleted EventBridge rule');
   } catch (error) {
+    // Deleting a rule that was never created (e.g. an opt-out tag on an alarm
+    // that never had an override schedule) is the common case - treat it as a
+    // successful no-op instead of failing the record.
+    if (error instanceof Error && error.name === 'ResourceNotFoundException') {
+      log
+        .debug()
+        .str('function', 'deleteEventBridgeRule')
+        .str('alarmName', alarmName)
+        .str('ruleName', ruleName)
+        .msg('Rule did not exist - nothing to delete');
+      return;
+    }
     log
       .error()
       .str('function', 'deleteEventBridgeRule')
@@ -259,7 +277,9 @@ export const handler: Handler = async (
         .obj('MetricAlarms', MetricAlarms)
         .msg('Alarm details');
 
-      if (!MetricAlarms) {
+      // DescribeAlarms returns MetricAlarms: [] (truthy) for nonexistent
+      // alarms, so we must check the length to detect "not found".
+      if (!MetricAlarms?.length) {
         log
           .info()
           .str('function', 'handler')
@@ -301,6 +321,23 @@ export const handler: Handler = async (
           .msg('Invalid or missing tag value - deleting existing rule');
 
         // Delete the rule if tag is invalid or missing
+        await deleteEventBridgeRule(alarmName);
+        continue; // Continue to next record instead of returning
+      }
+
+      // Enforce schedule bounds - treat out-of-bounds values as invalid
+      if (minutes < MIN_REALARM_MINUTES || minutes > MAX_REALARM_MINUTES) {
+        log
+          .warn()
+          .str('function', 'handler')
+          .str('resourceARN', resourceARN)
+          .num('minutes', minutes)
+          .num('minMinutes', MIN_REALARM_MINUTES)
+          .num('maxMinutes', MAX_REALARM_MINUTES)
+          .msg(
+            'Tag value outside allowed bounds - treating as invalid and deleting existing rule',
+          );
+
         await deleteEventBridgeRule(alarmName);
         continue; // Continue to next record instead of returning
       }


### PR DESCRIPTION
PR 5 of 9 from the verified AutoAlarm code review. All findings are MEDIUM severity and confined to the ReAlarm subsystem.

**Product decision (user-confirmed):** ReAlarm intentionally operates on ALL account alarms (opt-out via `autoalarm:re-alarm-enabled=false`); it is NOT scoped to AutoAlarm-* alarms. This PR documents that behavior prominently in the README rather than changing it.

## Findings fixed

1. **Dead not-found check** — `handlers/src/realarm-tag-event-handler.mts`: `DescribeAlarms` returns `MetricAlarms: []` (truthy) for nonexistent alarms, so `if (!MetricAlarms)` never fired and the handler created orphan EventBridge schedule rules that invoke the producer forever. Now checks `!MetricAlarms?.length`.
2. **Rule-delete idempotency** — `handlers/src/realarm-tag-event-handler.mts` `deleteEventBridgeRule`: `RemoveTargets`/`DeleteRule` throw `ResourceNotFoundException` when the rule never existed (the common case for opt-out tags), causing 3 SQS retries + DLQ noise per tag event. Now treated as a successful no-op (debug log); all other errors still rethrow.
3. **re-alarm-minutes bounds** — `handlers/src/realarm-tag-event-handler.mts`: a `1`-minute tag created a per-minute schedule that scans every alarm in the account, settable by any tagger. Values are now bounded to 5–1440 minutes; out-of-bounds values log a warning and take the same delete-rule path as other invalid values. Documented in the README ReAlarm section.
4. **Failure attribution** — `handlers/src/realarm-consumer-handler.mts`: failed results were mapped back to SQS records via first-match substring on alarm name, so the wrong messageId could be retried while the actually-failed record was ACKed. Parsed messages now carry their originating record, and failures are attributed by index/messageId; the substring search is removed.
5. **Override-tag numeric check** — `handlers/src/realarm-consumer-handler.mts`: `!isNaN(Number(tag.Value))` treated `''`/`' '`/`'0'` as a numeric override (`Number('') === 0`) while the tag handler deletes the rule for those values, excluding the alarm from BOTH re-alarm paths. The consumer now requires a real positive integer, mirroring the tag handler.
6. **Tag-fetch failures no longer swallowed** — `handlers/src/realarm-consumer-handler.mts`: a failed `ListTagsForResource` previously fell through to processing with an empty tag set, resetting alarms whose owners opted out. Failed ARNs are now tracked; their messages are skipped and reported as `batchItemFailures` so SQS retries them.
7. **Throttle detection actually engages** — both consumer and producer: `THROTTLING_ERROR_CODES` lacked CloudWatch's `Throttling` and SQS's `RequestThrottled` names, so adaptive pacing never triggered. Both names added, and detection now matches `error.name` first with a message-substring fallback.
8. **Retry storm fix** — both consumer and producer: `new ConfiguredRetryStrategy(20)` (20 attempts at constant ~100ms) replaced with `ConfiguredRetryStrategy(5, (attempt) => 100 + attempt * 1000)`. (Other files are covered by sibling PRs.)
9. **Producer batch sending** — `handlers/src/realarm-producer-handler.mts`: removed the fixed 1000ms sleep after every 10-message batch (~8 min pure sleep per 5k alarms) and the provably dead adaptive-delay code (`batchThrottleCount` was per-iteration and only incremented in a rethrowing catch). Batches now send with bounded concurrency (groups of 5 `SendMessageBatch` calls) with a small 100ms pause between groups; throttling is handled by the SDK retry strategy.
10. **Autoscaling exclusion precision** — `handlers/src/realarm-consumer-handler.mts`: `action.includes('autoscaling')` matched anywhere in the action ARN, so e.g. an SNS topic named `...autoscaling-alerts` permanently excluded its alarm. Now parses the ARN service segment and matches `autoscaling` or `application-autoscaling` exactly.
11. **IAM scoping + docs** — `cdk/lib/realarm-consumer-subconstruct.ts`: `cloudwatch:SetAlarmState` is now scoped to `arn:aws:cloudwatch:<region>:<account>:alarm:*` (via `Stack.of(this).formatArn`) instead of `*`; `DescribeAlarms`/`ListTagsForResource` remain on `*` as list/read operations. README gains a prominent note that ReAlarm resets every account alarm in ALARM state by default, with the tag opt-out and automatic autoscaling exclusion.

## Verification

- `handlers`: `tsc --noEmit` clean, `eslint` clean, `vitest` 13/13 passed
- `cdk`: `prettier --check` + `eslint` (prebuild) clean, `tsc` build clean, `jest` 1/1 passed