### PR TITLE
Table-driven EventBridge rules with config-derived tag keys (closes #237)

### DIFF
--- a/cdk/lib/auto-alarm.test.ts
+++ b/cdk/lib/auto-alarm.test.ts
@@ -1,6 +1,7 @@
 import {App} from 'aws-cdk-lib';
 import {Match, Template} from 'aws-cdk-lib/assertions';
 import {AutoAlarmStack} from './auto-alarm-stack';
+import {SERVICE_DESCRIPTORS} from './service-eventbridge-subconstruct';
 
 /**
  * Synthesizes the AutoAlarm stack once and runs assertions against the
@@ -118,6 +119,67 @@ describe('AutoAlarm stack', () => {
       expect(mapping.Properties?.FunctionResponseTypes).toEqual([
         'ReportBatchItemFailures',
       ]);
+    }
+  });
+
+  test('service event rule count matches the descriptor table', () => {
+    const ruleIds = Object.keys(template.findResources('AWS::Events::Rule'));
+    const serviceRuleIds = ruleIds.filter((id) =>
+      id.includes('ServiceEventRules'),
+    );
+    const expected = SERVICE_DESCRIPTORS.reduce(
+      (count, service) => count + service.rules.length,
+      0,
+    );
+    expect(serviceRuleIds.length).toBe(expected);
+  });
+
+  test('every service event rule has exactly one SQS target with a DLQ', () => {
+    const rules = template.findResources('AWS::Events::Rule');
+    for (const [logicalId, rule] of Object.entries(rules)) {
+      if (!logicalId.includes('ServiceEventRules')) {
+        continue;
+      }
+      const targets = rule.Properties?.Targets ?? [];
+      expect({logicalId, targetCount: targets.length}).toEqual({
+        logicalId,
+        targetCount: 1,
+      });
+      const target = targets[0];
+      // Target is an SQS queue (queue ARN + FIFO SqsParameters) with a
+      // dead-letter queue for undeliverable events (#234).
+      expect(target.Arn?.['Fn::GetAtt']?.[1]).toBe('Arn');
+      expect(target.SqsParameters?.MessageGroupId).toMatch(
+        /^AutoAlarm-[a-z0-9]+$/,
+      );
+      expect(target.DeadLetterConfig?.Arn).toBeDefined();
+    }
+  });
+
+  test('each descriptor rule synthesizes its exact event pattern, message group id, and DLQ', () => {
+    for (const service of SERVICE_DESCRIPTORS) {
+      for (const rule of service.rules) {
+        // Array properties (including changed-tag-keys, which is derived
+        // from the handler alarm configs via service-tag-keys.ts) are
+        // matched exactly by the assertions module, so this also guards
+        // each tag rule's changed-tag-keys list.
+        template.hasResourceProperties('AWS::Events::Rule', {
+          Description: rule.description,
+          EventPattern: {
+            'source': rule.eventPattern.source,
+            'detail-type': rule.eventPattern.detailType,
+            'detail': rule.eventPattern.detail,
+          },
+          Targets: [
+            Match.objectLike({
+              SqsParameters: {
+                MessageGroupId: `AutoAlarm-${service.serviceName}`,
+              },
+              DeadLetterConfig: Match.objectLike({Arn: Match.anyValue()}),
+            }),
+          ],
+        });
+      }
     }
   });
 

--- a/cdk/lib/service-eventbridge-subconstruct.ts
+++ b/cdk/lib/service-eventbridge-subconstruct.ts
@@ -1,10 +1,11 @@
 import {Construct} from 'constructs';
-import {Rule} from 'aws-cdk-lib/aws-events';
+import {EventPattern, Rule} from 'aws-cdk-lib/aws-events';
 import {SqsQueue} from 'aws-cdk-lib/aws-events-targets';
 import {IQueue} from 'aws-cdk-lib/aws-sqs';
 import {NoBreachingExtendedQueue} from './extended-libs-subconstruct';
+import {SERVICE_TAG_KEYS} from './service-tag-keys';
 
-type ServiceName =
+export type ServiceName =
   | 'alb'
   | 'cloudfront'
   | 'ec2'
@@ -20,13 +21,377 @@ type ServiceName =
   | 'transitgateway'
   | 'vpn';
 
-type RuleObject = {
-  [ruleName: string]: Rule;
-};
+interface ServiceRuleDescriptor {
+  /**
+   * CDK construct id for the rule. Preserved verbatim from the original
+   * per-service add*Rules methods so logical IDs (and therefore the deployed
+   * rules) do not churn.
+   */
+  readonly id: string;
+  readonly description: string;
+  readonly eventPattern: EventPattern;
+}
+
+export interface ServiceDescriptor {
+  readonly serviceName: ServiceName;
+  /** Key into SqsHandlerSubConstruct.eventSourceQueues for this service. */
+  readonly queueKey: string;
+  readonly rules: ServiceRuleDescriptor[];
+}
+
+/**
+ * Builds an event pattern for resource-tagging events
+ * ("Tag Change on Resource") filtered to the autoalarm tag keys the service
+ * supports. The changed-tag-keys lists live in service-tag-keys.ts and are
+ * kept in sync with handlers/src/alarm-configs by service-tag-keys.test.ts.
+ */
+function tagChangePattern(
+  service: string,
+  resourceType: string,
+  changedTagKeys: string[],
+): EventPattern {
+  return {
+    source: ['aws.tag'],
+    detailType: ['Tag Change on Resource'],
+    detail: {
+      'service': [service],
+      'resource-type': [resourceType],
+      'changed-tag-keys': changedTagKeys,
+    },
+  };
+}
+
+/**
+ * Builds an event pattern for CloudTrail-delivered API calls
+ * ("AWS API Call via CloudTrail") for the given event source and names.
+ */
+function cloudTrailPattern(
+  source: string,
+  eventSource: string,
+  eventNames: string[],
+): EventPattern {
+  return {
+    source: [source],
+    detailType: ['AWS API Call via CloudTrail'],
+    detail: {
+      eventSource: [eventSource],
+      eventName: eventNames,
+    },
+  };
+}
+
+/**
+ * Single source of truth for every service AutoAlarm routes EventBridge
+ * events for: each entry pairs a service's rules with its SQS handler queue
+ * by reference (queueKey), so a rule can never be wired to the wrong queue
+ * by name matching.
+ */
+export const SERVICE_DESCRIPTORS: ServiceDescriptor[] = [
+  {
+    serviceName: 'alb',
+    queueKey: 'AutoAlarm-Alb',
+    rules: [
+      {
+        id: 'AlbTagRule',
+        description: 'Routes ALB tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'elasticloadbalancing',
+          'loadbalancer',
+          SERVICE_TAG_KEYS.alb,
+        ),
+      },
+      {
+        id: 'AlbRule',
+        description: 'Routes ALB events to AutoAlarm',
+        eventPattern: cloudTrailPattern(
+          'aws.elasticloadbalancing',
+          'elasticloadbalancing.amazonaws.com',
+          ['CreateLoadBalancer', 'DeleteLoadBalancer'],
+        ),
+      },
+    ],
+  },
+  {
+    serviceName: 'cloudfront',
+    queueKey: 'AutoAlarm-Cloudfront',
+    rules: [
+      {
+        id: 'CloudStateRule',
+        description: 'Routes CloudFront events to AutoAlarm',
+        eventPattern: cloudTrailPattern(
+          'aws.cloudfront',
+          'cloudfront.amazonaws.com',
+          ['CreateDistribution', 'DeleteDistribution'],
+        ),
+      },
+      {
+        id: 'CloudFrontTagRule',
+        description: 'Routes CloudFront tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'cloudfront',
+          'distribution',
+          SERVICE_TAG_KEYS.cloudfront,
+        ),
+      },
+    ],
+  },
+  {
+    serviceName: 'ec2',
+    queueKey: 'AutoAlarm-Ec2',
+    rules: [
+      {
+        id: 'ec2TagRule',
+        description: 'Routes tag events to AutoAlarm',
+        eventPattern: tagChangePattern('ec2', 'instance', SERVICE_TAG_KEYS.ec2),
+      },
+      {
+        id: 'Ec2StateRule',
+        description: 'Routes ec2 instance events to AutoAlarm',
+        eventPattern: {
+          source: ['aws.ec2'],
+          detailType: ['EC2 Instance State-change Notification'],
+          detail: {
+            state: ['running', 'terminated'],
+          },
+        },
+      },
+    ],
+  },
+  {
+    serviceName: 'ecs',
+    queueKey: 'AutoAlarm-Ecs',
+    rules: [
+      {
+        id: 'EcsStateRule',
+        description: 'Routes ECS state change and tag events to AutoAlarm',
+        eventPattern: cloudTrailPattern('aws.ecs', 'ecs.amazonaws.com', [
+          'DeleteService',
+          'CreateService',
+          'TagResource',
+          'UntagResource',
+        ]),
+      },
+    ],
+  },
+  {
+    serviceName: 'logs',
+    queueKey: 'AutoAlarm-Logs',
+    rules: [
+      {
+        id: 'LogGroupStateRule',
+        description:
+          'Routes CloudWatch Logs create/delete/tag/untag events to AutoAlarm',
+        eventPattern: cloudTrailPattern('aws.logs', 'logs.amazonaws.com', [
+          'CreateLogGroup',
+          'DeleteLogGroup',
+          'TagResource',
+          'UntagResource',
+        ]),
+      },
+    ],
+  },
+  {
+    serviceName: 'opensearch',
+    queueKey: 'AutoAlarm-OpenSearchRule',
+    rules: [
+      {
+        id: 'OpenSearchTagRule',
+        description: 'Routes OpenSearch tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'es',
+          'domain',
+          SERVICE_TAG_KEYS.opensearch,
+        ),
+      },
+      {
+        id: 'OpenSearchStateRule',
+        description: 'Routes OpenSearch events to AutoAlarm',
+        eventPattern: cloudTrailPattern('aws.es', 'es.amazonaws.com', [
+          'CreateDomain',
+          'DeleteDomain',
+        ]),
+      },
+    ],
+  },
+  {
+    serviceName: 'rds',
+    queueKey: 'AutoAlarm-Rds',
+    rules: [
+      {
+        id: 'RDSTagRule',
+        description: 'Routes RDS tag events to AutoAlarm',
+        eventPattern: tagChangePattern('rds', 'db', SERVICE_TAG_KEYS.rds),
+      },
+      {
+        id: 'RDSStateRule',
+        description: 'Routes RDS events to AutoAlarm',
+        eventPattern: cloudTrailPattern('aws.rds', 'rds.amazonaws.com', [
+          'CreateDBInstance',
+          'DeleteDBInstance',
+        ]),
+      },
+    ],
+  },
+  {
+    serviceName: 'rdscluster',
+    queueKey: 'AutoAlarm-RdsCluster',
+    rules: [
+      {
+        id: 'RDSClusterTagRule',
+        description: 'Routes RDS Cluster tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'rds',
+          'cluster',
+          SERVICE_TAG_KEYS.rdscluster,
+        ),
+      },
+      {
+        id: 'RDSClusterStateRule',
+        description: 'Routes RDS Cluster events to AutoAlarm',
+        eventPattern: cloudTrailPattern('aws.rds', 'rds.amazonaws.com', [
+          'CreateDBCluster',
+          'DeleteDBCluster',
+        ]),
+      },
+    ],
+  },
+  {
+    serviceName: 'route53resolver',
+    queueKey: 'AutoAlarm-Route53resolver',
+    rules: [
+      {
+        id: 'Route53ResolverTagRule',
+        description: 'Routes Route53Resolver tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'route53resolver',
+          'resolver-endpoint',
+          SERVICE_TAG_KEYS.route53resolver,
+        ),
+      },
+      {
+        id: 'Route53ResolverStateRule',
+        description: 'Routes Route53Resolver events to AutoAlarm',
+        eventPattern: cloudTrailPattern(
+          'aws.route53resolver',
+          'route53resolver.amazonaws.com',
+          ['CreateResolverEndpoint', 'DeleteResolverEndpoint'],
+        ),
+      },
+    ],
+  },
+  {
+    serviceName: 'sqs',
+    queueKey: 'AutoAlarm-Sqs',
+    rules: [
+      {
+        id: 'SqsRule',
+        description: 'Routes SQS events to AutoAlarm',
+        eventPattern: cloudTrailPattern('aws.sqs', 'sqs.amazonaws.com', [
+          'CreateQueue',
+          'DeleteQueue',
+          'TagQueue',
+          'UntagQueue',
+        ]),
+      },
+    ],
+  },
+  {
+    serviceName: 'sfn',
+    queueKey: 'AutoAlarm-Sfn',
+    rules: [
+      {
+        id: 'SFNRule',
+        description: 'Routes Step Functions events to AutoAlarm',
+        eventPattern: cloudTrailPattern('aws.states', 'states.amazonaws.com', [
+          'CreateStateMachine',
+          'DeleteStateMachine',
+        ]),
+      },
+      {
+        id: 'SFNTagRule',
+        description: 'Routes Step Functions tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'states',
+          'stateMachine',
+          SERVICE_TAG_KEYS.sfn,
+        ),
+      },
+    ],
+  },
+  {
+    serviceName: 'targetgroup',
+    queueKey: 'AutoAlarm-TargetGroup',
+    rules: [
+      {
+        id: 'TargetGroupTagRule',
+        description: 'Routes Target Group tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'elasticloadbalancing',
+          'targetgroup',
+          SERVICE_TAG_KEYS.targetgroup,
+        ),
+      },
+      {
+        id: 'TargetGroupStateRule',
+        description: 'Routes Target Group events to AutoAlarm',
+        eventPattern: cloudTrailPattern(
+          'aws.elasticloadbalancing',
+          'elasticloadbalancing.amazonaws.com',
+          ['CreateTargetGroup', 'DeleteTargetGroup'],
+        ),
+      },
+    ],
+  },
+  {
+    serviceName: 'transitgateway',
+    queueKey: 'AutoAlarm-TransitGateway',
+    rules: [
+      {
+        id: 'TransitGatewayTagRule',
+        description: 'Routes Transit Gateway tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'ec2',
+          'transit-gateway',
+          SERVICE_TAG_KEYS.transitgateway,
+        ),
+      },
+      {
+        id: 'TransitGatewayStateRule',
+        description: 'Routes Transit Gateway events to AutoAlarm',
+        eventPattern: cloudTrailPattern('aws.ec2', 'ec2.amazonaws.com', [
+          'CreateTransitGateway',
+          'DeleteTransitGateway',
+        ]),
+      },
+    ],
+  },
+  {
+    serviceName: 'vpn',
+    queueKey: 'AutoAlarm-Vpn',
+    rules: [
+      {
+        id: 'VPNTagRule',
+        description: 'Routes VPN tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'ec2',
+          'vpn-connection',
+          SERVICE_TAG_KEYS.vpn,
+        ),
+      },
+      {
+        id: 'VPNStateRule',
+        description: 'Routes VPN events to AutoAlarm',
+        eventPattern: cloudTrailPattern('aws.ec2', 'ec2.amazonaws.com', [
+          'CreateVpnConnection',
+          'DeleteVpnConnection',
+        ]),
+      },
+    ],
+  },
+];
 
 export class EventRules extends Construct {
-  public readonly serviceRules: Map<ServiceName, RuleObject[]>;
-  private readonly eventRuleTargetDLQ: IQueue;
+  public readonly serviceRules: Map<ServiceName, Rule[]>;
 
   constructor(
     scope: Construct,
@@ -35,682 +400,35 @@ export class EventRules extends Construct {
     eventRuleTargetDLQ: IQueue,
   ) {
     super(scope, id);
-    this.eventRuleTargetDLQ = eventRuleTargetDLQ;
     this.serviceRules = new Map();
-    this.initializeServiceEventRules();
-    this.eventRuleTargetSetter(this, queues);
-  }
 
-  /**
-   * Initialize the rules map with empty arrays for each service
-   * Annoyingly, we can't loop through attributes of a type so we have to manually be a bit repetitive here.
-   * @private
-   */
-  private initializeServiceEventRules() {
-    const services: ServiceName[] = [
-      'alb',
-      'cloudfront',
-      'ec2',
-      'ecs',
-      'logs',
-      'opensearch',
-      'rds',
-      'rdscluster',
-      'route53resolver',
-      'sqs',
-      'sfn',
-      'targetgroup',
-      'transitgateway',
-      'vpn',
-    ];
+    for (const service of SERVICE_DESCRIPTORS) {
+      const queue = queues[service.queueKey];
+      if (!queue) {
+        throw new Error(
+          `No queue found for key "${service.queueKey}" (service: ${service.serviceName})`,
+        );
+      }
 
-    /**
-     * Initialize the rules map with empty arrays for each service
-     */
-    services.forEach((service) => {
-      this.serviceRules.set(service, []);
-    });
+      const rules = service.rules.map((descriptor) => {
+        const rule = new Rule(this, descriptor.id, {
+          eventPattern: descriptor.eventPattern,
+          description: descriptor.description,
+        });
 
-    /**
-     * Add rules for each service
-     */
-    this.addAlbRules();
-    this.addCloudFrontRules();
-    this.addEc2Rules();
-    this.addEcsRules();
-    this.addLogGroupRules();
-    this.addOpenSearchRules();
-    this.addRdsRules();
-    this.addRdsClusterRules();
-    this.addRoute53ResolverRules();
-    this.addSqsRules();
-    this.addSNFRules();
-    this.addTargetGroupRules();
-    this.addTransitGatewayRules();
-    this.addVpnRules();
-  }
-
-  private addAlbRules() {
-    const albRules = this.serviceRules.get('alb') || [];
-
-    albRules.push({
-      albTagRule: new Rule(this, 'AlbTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['elasticloadbalancing'],
-            'resource-type': ['loadbalancer'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:request-count',
-              'autoalarm:4xx-count',
-              'autoalarm:5xx-count',
-              'autoalarm:request-count-anomaly',
-              'autoalarm:4xx-count-anomaly',
-              'autoalarm:5xx-count-anomaly',
-            ],
-          },
-        },
-        description: 'Routes ALB tag events to AutoAlarm',
-      }),
-    });
-
-    albRules.push({
-      albStateRule: new Rule(this, 'AlbRule', {
-        eventPattern: {
-          source: ['aws.elasticloadbalancing'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['elasticloadbalancing.amazonaws.com'],
-            eventName: ['CreateLoadBalancer', 'DeleteLoadBalancer'],
-          },
-        },
-        description: 'Routes ALB events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('alb', albRules);
-  }
-
-  private addCloudFrontRules() {
-    const cloudFrontRules = this.serviceRules.get('cloudfront') || [];
-
-    cloudFrontRules.push({
-      cloudStateRule: new Rule(this, 'CloudStateRule', {
-        eventPattern: {
-          source: ['aws.cloudfront'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['cloudfront.amazonaws.com'],
-            eventName: ['CreateDistribution', 'DeleteDistribution'],
-          },
-        },
-        description: 'Routes CloudFront events to AutoAlarm',
-      }),
-    });
-
-    cloudFrontRules.push({
-      cloudFrontTagRule: new Rule(this, 'CloudFrontTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['cloudfront'],
-            'resource-type': ['distribution'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:4xx-errors',
-              'autoalarm:4xx-errors-anomaly',
-              'autoalarm:5xx-errors',
-              'autoalarm:5xx-errors-anomaly',
-            ],
-          },
-        },
-        description: 'Routes CloudFront tag events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('cloudfront', cloudFrontRules);
-  }
-
-  private addEc2Rules() {
-    const ec2Rules = this.serviceRules.get('ec2') || [];
-    ec2Rules.push({
-      ec2TagRule: new Rule(this, 'ec2TagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['ec2'],
-            'resource-type': ['instance'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:cpu',
-              'autoalarm:storage',
-              'autoalarm:memory',
-              'autoalarm:cpu-anomaly',
-              'autoalarm:storage-anomaly',
-              'autoalarm:memory-anomaly',
-              'autoalarm:target',
-              'autoalarm:network-in-anomaly',
-              'autoalarm:network-in',
-              'autoalarm:network-out-anomaly',
-              'autoalarm:network-out',
-            ],
-          },
-        },
-        description: 'Routes tag events to AutoAlarm',
-      }),
-    });
-
-    ec2Rules.push({
-      ec2StateRule: new Rule(this, 'Ec2StateRule', {
-        eventPattern: {
-          source: ['aws.ec2'],
-          detailType: ['EC2 Instance State-change Notification'],
-          detail: {
-            state: [
-              'running',
-              'terminated',
-              //'stopped', //for testing only
-              //'shutting-down', //to be removed. for testing only
-              //'pending',
-            ],
-          },
-        },
-        description: 'Routes ec2 instance events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('ec2', ec2Rules);
-  }
-
-  private addEcsRules() {
-    const ecsRules = this.serviceRules.get('ecs') || [];
-
-    ecsRules.push({
-      ecsStateRule: new Rule(this, 'EcsStateRule', {
-        eventPattern: {
-          source: ['aws.ecs'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['ecs.amazonaws.com'],
-            eventName: [
-              'DeleteService',
-              'CreateService',
-              'TagResource',
-              'UntagResource',
-            ],
-          },
-        },
-        description: 'Routes ECS state change and tag events to AutoAlarm',
-      }),
-    });
-    this.serviceRules.set('ecs', ecsRules);
-  }
-
-  private addLogGroupRules() {
-    const logGroupRules = this.serviceRules.get('logs') || [];
-
-    logGroupRules.push({
-      logGroupStateRule: new Rule(this, 'LogGroupStateRule', {
-        eventPattern: {
-          source: ['aws.logs'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['logs.amazonaws.com'],
-            // Include create/delete + tag/untag events
-            eventName: [
-              'CreateLogGroup',
-              'DeleteLogGroup',
-              'TagResource',
-              'UntagResource',
-            ],
-          },
-        },
-        description:
-          'Routes CloudWatch Logs create/delete/tag/untag events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('logs', logGroupRules);
-  }
-
-  private addOpenSearchRules() {
-    const openSearchRules = this.serviceRules.get('opensearch') || [];
-
-    openSearchRules.push({
-      openSearchTagRule: new Rule(this, 'OpenSearchTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['es'],
-            'resource-type': ['domain'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:4xx-errors',
-              'autoalarm:4xx-errors-anomaly',
-              'autoalarm:5xx-errors',
-              'autoalarm:5xx-errors-anomaly',
-              'autoalarm:cpu',
-              'autoalarm:cpu-anomaly',
-              'autoalarm:iops-throttle',
-              'autoalarm:iops-throttle-anomaly',
-              'autoalarm:jvm-memory',
-              'autoalarm:jvm-memory-anomaly',
-              'autoalarm:read-latency',
-              'autoalarm:read-latency-anomaly',
-              'autoalarm:search-latency',
-              'autoalarm:search-latency-anomaly',
-              'autoalarm:snapshot-failure',
-              'autoalarm:storage',
-              'autoalarm:storage-anomaly',
-              'autoalarm:throughput-throttle',
-              'autoalarm:throughput-throttle-anomaly',
-              'autoalarm:write-latency',
-              'autoalarm:write-latency-anomaly',
-              'autoalarm:yellow-cluster',
-              'autoalarm:red-cluster',
-              'autoalarm:index-writes-blocked',
-            ],
-          },
-        },
-        description: 'Routes OpenSearch tag events to AutoAlarm',
-      }),
-    });
-
-    openSearchRules.push({
-      openSearchStateRule: new Rule(this, 'OpenSearchStateRule', {
-        eventPattern: {
-          source: ['aws.es'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['es.amazonaws.com'],
-            eventName: ['CreateDomain', 'DeleteDomain'],
-          },
-        },
-        description: 'Routes OpenSearch events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('opensearch', openSearchRules);
-  }
-
-  private addRdsRules() {
-    const rdsRules = this.serviceRules.get('rds') || [];
-
-    rdsRules.push({
-      rdsTagRule: new Rule(this, 'RDSTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['rds'],
-            'resource-type': ['db'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:cpu',
-              'autoalarm:cpu-anomaly',
-              'autoalarm:write-latency',
-              'autoalarm:write-latency-anomaly',
-              'autoalarm:read-latency',
-              'autoalarm:read-latency-anomaly',
-              'autoalarm:freeable-memory',
-              'autoalarm:freeable-memory-anomaly',
-              'autoalarm:db-connections',
-              'autoalarm:db-connections-anomaly',
-              'autoalarm:dbload-anomaly',
-              'autoalarm:swap-usage',
-              'autoalarm:deadlocks',
-              'autoalarm:disk-queue-depth-anomaly',
-              'autoalarm:disk-queue-depth',
-              'autoalarm:read-throughput-anomaly',
-              'autoalarm:write-throughput-anomaly',
-            ],
-          },
-        },
-        description: 'Routes RDS tag events to AutoAlarm',
-      }),
-    });
-
-    rdsRules.push({
-      rdsStateRule: new Rule(this, 'RDSStateRule', {
-        eventPattern: {
-          source: ['aws.rds'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['rds.amazonaws.com'],
-            eventName: ['CreateDBInstance', 'DeleteDBInstance'],
-          },
-        },
-        description: 'Routes RDS events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('rds', rdsRules);
-  }
-
-  private addRdsClusterRules() {
-    const rdsClusterRules = this.serviceRules.get('rdscluster') || [];
-
-    rdsClusterRules.push({
-      rdsClusterTagRule: new Rule(this, 'RDSClusterTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['rds'],
-            'resource-type': ['cluster'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:db-connections-anomaly',
-              'autoalarm:replica-lag',
-              'autoalarm:replica-lag-anomaly',
-            ],
-          },
-        },
-        description: 'Routes RDS Cluster tag events to AutoAlarm',
-      }),
-    });
-
-    rdsClusterRules.push({
-      rdsClusterStateRule: new Rule(this, 'RDSClusterStateRule', {
-        eventPattern: {
-          source: ['aws.rds'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['rds.amazonaws.com'],
-            eventName: ['CreateDBCluster', 'DeleteDBCluster'],
-          },
-        },
-        description: 'Routes RDS Cluster events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('rdscluster', rdsClusterRules);
-  }
-
-  private addRoute53ResolverRules() {
-    const route53ResolverRules = this.serviceRules.get('route53resolver') || [];
-
-    route53ResolverRules.push({
-      route53ResolverTagRule: new Rule(this, 'Route53ResolverTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['route53resolver'],
-            'resource-type': ['resolver-endpoint'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:inbound-query-volume',
-              'autoalarm:inbound-query-volume-anomaly',
-              'autoalarm:outbound-query-volume',
-              'autoalarm:outbound-query-volume-anomaly',
-            ],
-          },
-        },
-        description: 'Routes Route53Resolver tag events to AutoAlarm',
-      }),
-    });
-
-    route53ResolverRules.push({
-      route53ResolverStateRule: new Rule(this, 'Route53ResolverStateRule', {
-        eventPattern: {
-          source: ['aws.route53resolver'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['route53resolver.amazonaws.com'],
-            eventName: ['CreateResolverEndpoint', 'DeleteResolverEndpoint'],
-          },
-        },
-        description: 'Routes Route53Resolver events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('route53resolver', route53ResolverRules);
-  }
-
-  private addSqsRules() {
-    const sqsRules = this.serviceRules.get('sqs') || [];
-
-    sqsRules.push({
-      sqsStateRule: new Rule(this, 'SqsRule', {
-        eventPattern: {
-          source: ['aws.sqs'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['sqs.amazonaws.com'],
-            eventName: ['CreateQueue', 'DeleteQueue', 'TagQueue', 'UntagQueue'],
-          },
-        },
-        description: 'Routes SQS events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('sqs', sqsRules);
-  }
-
-  private addSNFRules() {
-    const sfnRules = this.serviceRules.get('sfn') || [];
-
-    sfnRules.push({
-      sfnStateRule: new Rule(this, 'SFNRule', {
-        eventPattern: {
-          source: ['aws.states'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['states.amazonaws.com'],
-            eventName: ['CreateStateMachine', 'DeleteStateMachine'],
-          },
-        },
-        description: 'Routes Step Functions events to AutoAlarm',
-      }),
-    });
-
-    sfnRules.push({
-      sfnTagRule: new Rule(this, 'SFNTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['states'],
-            'resource-type': ['stateMachine'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:executions-failed',
-              'autoalarm:executions-failed-anomaly',
-              'autoalarm:executions-timed-out',
-              'autoalarm:executions-timed-out-anomaly',
-            ],
-          },
-        },
-        description: 'Routes Step Functions tag events to AutoAlarm',
-      }),
-    });
-    this.serviceRules.set('sfn', sfnRules);
-  }
-
-  private addTargetGroupRules() {
-    const targetGroupRules = this.serviceRules.get('targetgroup') || [];
-
-    targetGroupRules.push({
-      targetGroupTagRule: new Rule(this, 'TargetGroupTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['elasticloadbalancing'],
-            'resource-type': ['targetgroup'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:unhealthy-host-count',
-              'autoalarm:response-time',
-              'autoalarm:4xx-count',
-              'autoalarm:5xx-count',
-              'autoalarm:unhealthy-host-count-anomaly',
-              'autoalarm:response-time-anomaly',
-              'autoalarm:4xx-count-anomaly',
-              'autoalarm:5xx-count-anomaly',
-              'autoalarm:healthy-host-count',
-            ],
-          },
-        },
-        description: 'Routes Target Group tag events to AutoAlarm',
-      }),
-    });
-
-    targetGroupRules.push({
-      targetGroupStateRule: new Rule(this, 'TargetGroupStateRule', {
-        eventPattern: {
-          source: ['aws.elasticloadbalancing'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['elasticloadbalancing.amazonaws.com'],
-            eventName: ['CreateTargetGroup', 'DeleteTargetGroup'],
-          },
-        },
-        description: 'Routes Target Group events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('targetgroup', targetGroupRules);
-  }
-
-  private addTransitGatewayRules() {
-    const transitGatewayRules = this.serviceRules.get('transitgateway') || [];
-
-    transitGatewayRules.push({
-      transitGatewayTagRule: new Rule(this, 'TransitGatewayTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['ec2'],
-            'resource-type': ['transit-gateway'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:bytes-in',
-              'autoalarm:bytes-in-anomaly',
-              'autoalarm:bytes-out',
-              'autoalarm:bytes-out-anomaly',
-            ],
-          },
-        },
-        description: 'Routes Transit Gateway tag events to AutoAlarm',
-      }),
-    });
-
-    transitGatewayRules.push({
-      transitGatewayStateRule: new Rule(this, 'TransitGatewayStateRule', {
-        eventPattern: {
-          source: ['aws.ec2'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['ec2.amazonaws.com'],
-            eventName: ['CreateTransitGateway', 'DeleteTransitGateway'],
-          },
-        },
-        description: 'Routes Transit Gateway events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('transitgateway', transitGatewayRules);
-  }
-
-  private addVpnRules() {
-    const vpnRules = this.serviceRules.get('vpn') || [];
-
-    vpnRules.push({
-      vpnTagRule: new Rule(this, 'VPNTagRule', {
-        eventPattern: {
-          source: ['aws.tag'],
-          detailType: ['Tag Change on Resource'],
-          detail: {
-            'service': ['ec2'],
-            'resource-type': ['vpn-connection'],
-            'changed-tag-keys': [
-              'autoalarm:enabled',
-              'autoalarm:tunnel-state',
-              'autoalarm:tunnel-state-anomaly',
-            ],
-          },
-        },
-        description: 'Routes VPN tag events to AutoAlarm',
-      }),
-    });
-
-    vpnRules.push({
-      vpnStateRule: new Rule(this, 'VPNStateRule', {
-        eventPattern: {
-          source: ['aws.ec2'],
-          detailType: ['AWS API Call via CloudTrail'],
-          detail: {
-            eventSource: ['ec2.amazonaws.com'],
-            eventName: ['CreateVpnConnection', 'DeleteVpnConnection'],
-          },
-        },
-        description: 'Routes VPN events to AutoAlarm',
-      }),
-    });
-
-    this.serviceRules.set('vpn', vpnRules);
-  }
-
-  /**
-   * Private method to set targets for each rule
-   * @param eventBridgeRules - The rule to add targets to
-   * @param queues - an object containing the queues to add as targets
-   */
-  private eventRuleTargetSetter(
-    eventBridgeRules: EventRules,
-    queues: {[key: string]: NoBreachingExtendedQueue},
-  ): void {
-    try {
-      for (const serviceName of eventBridgeRules.serviceRules.keys()) {
-        // Find queue where the key includes the service name
-        const queueKey = Object.keys(queues).find((key) =>
-          key.toLowerCase().includes(serviceName.toLowerCase()),
+        rule.addTarget(
+          new SqsQueue(queue, {
+            messageGroupId: `AutoAlarm-${service.serviceName}`,
+            // Capture events EventBridge could not deliver to the
+            // target queue after its retry policy is exhausted.
+            deadLetterQueue: eventRuleTargetDLQ,
+          }),
         );
 
-        if (!queueKey) {
-          throw new Error(
-            `No queue found containing service name: ${serviceName}`,
-          );
-        }
+        return rule;
+      });
 
-        const queue = queues[queueKey];
-        const serviceRules = eventBridgeRules.serviceRules.get(serviceName);
-
-        if (!serviceRules) {
-          throw new Error(`No rules found for service: ${serviceName}`);
-        }
-
-        serviceRules.forEach((ruleObj) => {
-          Object.values(ruleObj).forEach((rule) => {
-            try {
-              rule.addTarget(
-                new SqsQueue(queue, {
-                  messageGroupId: `AutoAlarm-${serviceName}`,
-                  // Capture events EventBridge could not deliver to the
-                  // target queue after its retry policy is exhausted.
-                  deadLetterQueue: this.eventRuleTargetDLQ,
-                }),
-              );
-            } catch (error) {
-              console.error(
-                `Error adding target for rule in service ${serviceName}:`,
-                error,
-              );
-            }
-          });
-        });
-      }
-    } catch (error) {
-      console.error('Error in eventRuleTargetSetter:', error);
-      throw error;
+      this.serviceRules.set(service.serviceName, rules);
     }
   }
 }

--- a/cdk/lib/service-tag-keys.test.ts
+++ b/cdk/lib/service-tag-keys.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Drift guard for cdk/lib/service-tag-keys.ts.
+ *
+ * The CDK package is CommonJS and cannot import the ESM (.mts) handler
+ * sources through tsc, so the changed-tag-keys lists are materialized in
+ * service-tag-keys.ts. This test loads the REAL alarm-config arrays from
+ * handlers/src/alarm-configs (bundled on the fly with esbuild) and asserts
+ * each CDK-side list is exactly:
+ *
+ *   ['autoalarm:enabled', ...CONFIGS.map((c) => `autoalarm:${c.tagKey}`),
+ *    ...NON_CONFIG_TAG_KEYS[service] ?? []]
+ *
+ * Adding, removing, renaming, or reordering a tagKey in the handlers
+ * configs without updating service-tag-keys.ts fails this test (and CI).
+ */
+import * as path from 'path';
+import {createRequire} from 'module';
+import {buildSync} from 'esbuild';
+import {
+  NON_CONFIG_TAG_KEYS,
+  SERVICE_TAG_KEYS,
+  TagRuleService,
+} from './service-tag-keys';
+
+const HANDLERS_CONFIG_INDEX = path.resolve(
+  __dirname,
+  '..',
+  '..',
+  'handlers',
+  'src',
+  'alarm-configs',
+  '_index.mts',
+);
+
+/**
+ * Maps each service with a tag-change rule to its *_CONFIGS export in
+ * handlers/src/alarm-configs/_index.mts.
+ */
+const CONFIG_EXPORTS: Record<TagRuleService, string> = {
+  alb: 'ALB_CONFIGS',
+  cloudfront: 'CLOUDFRONT_CONFIGS',
+  ec2: 'EC2_CONFIGS',
+  opensearch: 'OPENSEARCH_CONFIGS',
+  rds: 'RDS_CONFIGS',
+  rdscluster: 'RDS_CLUSTER_CONFIGS',
+  route53resolver: 'ROUTE53_RESOLVER_CONFIGS',
+  sfn: 'STEP_FUNCTION_CONFIGS',
+  targetgroup: 'TARGET_GROUP_CONFIGS',
+  transitgateway: 'TRANSIT_GATEWAY_CONFIGS',
+  vpn: 'VPN_CONFIGS',
+};
+
+interface AlarmConfigLike {
+  tagKey: string;
+}
+
+/**
+ * Bundles the handlers alarm-config barrel to CommonJS in memory and
+ * evaluates it. Third-party packages (only used for enum values in the
+ * config defaults) stay external and are resolved from handlers'
+ * node_modules via createRequire.
+ */
+function loadHandlerAlarmConfigs(): Record<string, AlarmConfigLike[]> {
+  const result = buildSync({
+    entryPoints: [HANDLERS_CONFIG_INDEX],
+    bundle: true,
+    write: false,
+    format: 'cjs',
+    platform: 'node',
+    target: 'node20',
+    external: ['@aws-sdk/*', 'aws-cdk-lib', 'aws-cdk-lib/*'],
+    logLevel: 'silent',
+  });
+  const code = result.outputFiles[0].text;
+  const handlersRequire = createRequire(HANDLERS_CONFIG_INDEX);
+  const moduleShim = {exports: {} as Record<string, AlarmConfigLike[]>};
+  new Function('module', 'exports', 'require', code)(
+    moduleShim,
+    moduleShim.exports,
+    handlersRequire,
+  );
+  return moduleShim.exports;
+}
+
+describe('service-tag-keys stays in sync with handlers alarm configs', () => {
+  const handlerConfigs = loadHandlerAlarmConfigs();
+
+  for (const [service, exportName] of Object.entries(CONFIG_EXPORTS) as [
+    TagRuleService,
+    string,
+  ][]) {
+    test(`${service} changed-tag-keys are derived from ${exportName}`, () => {
+      const configs = handlerConfigs[exportName];
+      expect(Array.isArray(configs)).toBe(true);
+      expect(configs.length).toBeGreaterThan(0);
+
+      const derived = [
+        'autoalarm:enabled',
+        ...configs.map((config) => `autoalarm:${config.tagKey}`),
+        ...(NON_CONFIG_TAG_KEYS[service] ?? []),
+      ];
+
+      expect(SERVICE_TAG_KEYS[service]).toEqual(derived);
+    });
+  }
+});

--- a/cdk/lib/service-tag-keys.ts
+++ b/cdk/lib/service-tag-keys.ts
@@ -1,0 +1,172 @@
+/**
+ * Per-service `autoalarm:` tag keys used by the EventBridge tag-change rules
+ * (`changed-tag-keys` filters) in service-eventbridge-subconstruct.ts.
+ *
+ * Each list is derived from the corresponding alarm-config array in
+ * handlers/src/alarm-configs/*-configs.mts:
+ *
+ *   ['autoalarm:enabled', ...CONFIGS.map((c) => `autoalarm:${c.tagKey}`),
+ *    ...NON_CONFIG_TAG_KEYS[service] ?? []]
+ *
+ * The handlers package is ESM (.mts) and cannot be imported directly into
+ * this CommonJS CDK build (TS would need `module: nodenext` plus
+ * require(esm) support to import an ES module from CJS), so the lists are
+ * materialized here and guarded against drift by service-tag-keys.test.ts,
+ * which loads the real handler configs (bundled with esbuild) and asserts
+ * these lists match exactly. Adding, removing, or renaming a `tagKey` in
+ * handlers without updating this file fails CI.
+ */
+
+/**
+ * Services that have an EventBridge "Tag Change on Resource" rule filtered
+ * by changed-tag-keys. (ecs, logs, and sqs receive tag events via
+ * CloudTrail TagResource/UntagResource API-call rules instead.)
+ */
+export type TagRuleService =
+  | 'alb'
+  | 'cloudfront'
+  | 'ec2'
+  | 'opensearch'
+  | 'rds'
+  | 'rdscluster'
+  | 'route53resolver'
+  | 'sfn'
+  | 'targetgroup'
+  | 'transitgateway'
+  | 'vpn';
+
+/**
+ * Tag keys AutoAlarm reacts to that are NOT backed by a MetricAlarmConfig
+ * entry (behavior/routing tags rather than per-metric alarm tags).
+ */
+export const NON_CONFIG_TAG_KEYS: Partial<Record<TagRuleService, string[]>> = {
+  // Routes EC2 alarms between CloudWatch and Prometheus
+  // (see handlers/src/service-modules/ec2-modules.mts).
+  ec2: ['autoalarm:target'],
+};
+
+/**
+ * changed-tag-keys for each service's tag rule, in the same order as the
+ * corresponding *_CONFIGS array (order is irrelevant to EventBridge
+ * matching; keeping config order makes the drift test a strict equality).
+ */
+export const SERVICE_TAG_KEYS: Record<TagRuleService, string[]> = {
+  alb: [
+    'autoalarm:enabled',
+    'autoalarm:4xx-count',
+    'autoalarm:4xx-count-anomaly',
+    'autoalarm:5xx-count',
+    'autoalarm:5xx-count-anomaly',
+    'autoalarm:request-count',
+    'autoalarm:request-count-anomaly',
+  ],
+  cloudfront: [
+    'autoalarm:enabled',
+    'autoalarm:4xx-errors',
+    'autoalarm:4xx-errors-anomaly',
+    'autoalarm:5xx-errors',
+    'autoalarm:5xx-errors-anomaly',
+  ],
+  ec2: [
+    'autoalarm:enabled',
+    'autoalarm:cpu',
+    'autoalarm:cpu-anomaly',
+    'autoalarm:memory',
+    'autoalarm:memory-anomaly',
+    'autoalarm:storage',
+    'autoalarm:storage-anomaly',
+    'autoalarm:network-in',
+    'autoalarm:network-in-anomaly',
+    'autoalarm:network-out',
+    'autoalarm:network-out-anomaly',
+    'autoalarm:target',
+  ],
+  opensearch: [
+    'autoalarm:enabled',
+    'autoalarm:4xx-errors',
+    'autoalarm:4xx-errors-anomaly',
+    'autoalarm:5xx-errors',
+    'autoalarm:5xx-errors-anomaly',
+    'autoalarm:cpu',
+    'autoalarm:cpu-anomaly',
+    'autoalarm:iops-throttle',
+    'autoalarm:iops-throttle-anomaly',
+    'autoalarm:jvm-memory',
+    'autoalarm:jvm-memory-anomaly',
+    'autoalarm:read-latency',
+    'autoalarm:read-latency-anomaly',
+    'autoalarm:search-latency',
+    'autoalarm:search-latency-anomaly',
+    'autoalarm:snapshot-failure',
+    'autoalarm:storage',
+    'autoalarm:storage-anomaly',
+    'autoalarm:throughput-throttle',
+    'autoalarm:throughput-throttle-anomaly',
+    'autoalarm:write-latency',
+    'autoalarm:write-latency-anomaly',
+    'autoalarm:yellow-cluster',
+    'autoalarm:red-cluster',
+    'autoalarm:index-writes-blocked',
+  ],
+  rds: [
+    'autoalarm:enabled',
+    'autoalarm:cpu',
+    'autoalarm:db-connections-anomaly',
+    'autoalarm:dbload-anomaly',
+    'autoalarm:freeable-memory',
+    'autoalarm:freeable-memory-anomaly',
+    'autoalarm:write-latency',
+    'autoalarm:write-latency-anomaly',
+    'autoalarm:read-latency',
+    'autoalarm:read-latency-anomaly',
+    'autoalarm:swap-usage',
+    'autoalarm:deadlocks',
+    'autoalarm:disk-queue-depth',
+    'autoalarm:disk-queue-depth-anomaly',
+    'autoalarm:read-throughput-anomaly',
+    'autoalarm:write-throughput-anomaly',
+  ],
+  rdscluster: [
+    'autoalarm:enabled',
+    'autoalarm:db-connections-anomaly',
+    'autoalarm:replica-lag',
+    'autoalarm:replica-lag-anomaly',
+  ],
+  route53resolver: [
+    'autoalarm:enabled',
+    'autoalarm:inbound-query-volume',
+    'autoalarm:inbound-query-volume-anomaly',
+    'autoalarm:outbound-query-volume',
+    'autoalarm:outbound-query-volume-anomaly',
+  ],
+  sfn: [
+    'autoalarm:enabled',
+    'autoalarm:executions-failed',
+    'autoalarm:executions-failed-anomaly',
+    'autoalarm:executions-timed-out',
+    'autoalarm:executions-timed-out-anomaly',
+  ],
+  targetgroup: [
+    'autoalarm:enabled',
+    'autoalarm:4xx-count',
+    'autoalarm:4xx-count-anomaly',
+    'autoalarm:5xx-count',
+    'autoalarm:5xx-count-anomaly',
+    'autoalarm:response-time',
+    'autoalarm:response-time-anomaly',
+    'autoalarm:unhealthy-host-count',
+    'autoalarm:healthy-host-count',
+  ],
+  transitgateway: [
+    'autoalarm:enabled',
+    'autoalarm:bytes-in',
+    'autoalarm:bytes-in-anomaly',
+    'autoalarm:bytes-out',
+    'autoalarm:bytes-out-anomaly',
+  ],
+  vpn: [
+    'autoalarm:enabled',
+    'autoalarm:tunnel-state',
+    'autoalarm:tunnel-state-anomaly',
+  ],
+};


### PR DESCRIPTION
Closes #237.

## What changed

### Descriptor table (cdk/lib/service-eventbridge-subconstruct.ts)
The 14 near-identical `addXxxRules` methods (~575 lines) and the case-insensitive substring queue matcher (`eventRuleTargetSetter`) are replaced by a single exported `SERVICE_DESCRIPTORS` table: one entry per service of `{serviceName, queueKey, rules: [{id, description, eventPattern}]}`. Each rule is constructed together with its queue target — the queue is looked up once by its exact `eventSourceQueues` key (`queueKey`), so a rule can never be wired to the wrong queue by name matching (the old `'rds'`-matches-both-`AutoAlarm-Rds`-and-`AutoAlarm-RdsCluster` hazard is gone by construction). Two small helpers (`tagChangePattern`, `cloudTrailPattern`) build the patterns; all 25 rule construct ids are preserved verbatim, so **no logical-ID churn** (verified — see parity below). MessageGroupIds (`AutoAlarm-<serviceName>`), the shared target DLQ (#234), and FIFO target params are unchanged.

### Tag-key derivation — approach shipped: validated module + drift-guard test (fallback)
Direct import of `handlers/src/alarm-configs/*.mts` into the CDK build is intractable here: the cdk package is CommonJS (`module: commonjs`, ts-node synth, ts-jest), the handler sources are ESM-only `.mts`, and TypeScript ~5.6 cannot `require()` an ES module from CJS (TS1479; `require(esm)` support needs TS >= 5.8 + `module: nodenext`, or converting the whole cdk app to ESM). So per the issue's sanctioned fallback:

- `cdk/lib/service-tag-keys.ts` — the changed-tag-keys lists, materialized as `['autoalarm:enabled', ...CONFIGS.map(c => 'autoalarm:' + c.tagKey), ...NON_CONFIG_TAG_KEYS]` per service (with `NON_CONFIG_TAG_KEYS` documenting the one non-config behavior tag, `ec2: ['autoalarm:target']`).
- `cdk/lib/service-tag-keys.test.ts` — drift guard: bundles the real `handlers/src/alarm-configs/_index.mts` on the fly with esbuild (already a cdk devDependency; third-party enum imports stay external and resolve from handlers' node_modules), evaluates it, and asserts each cdk-side list **strictly equals** the derived list. Any tagKey added/removed/renamed/reordered in handlers without updating the cdk list fails CI. (It already proved itself: it caught that `volume-used` in rds-configs is commented out, which a grep-based reading missed.)

## Template parity (synth on develop vs. this branch, fake env)
189 resources in both templates; identical logical IDs throughout; outputs identical. Diff of all 27 `AWS::Events::Rule` resources (25 service + 2 ReAlarm):

| Rule | Diff |
|---|---|
| `AlbTagRule`, `ec2TagRule` | changed-tag-keys **order-only** (now config order; EventBridge treats the array as an OR'd set) |
| `RDSTagRule` | dropped stale keys `autoalarm:cpu-anomaly`, `autoalarm:db-connections` — **no rds config exists for either**, so events for them were dead routing (the drift class this PR eliminates) |
| `TargetGroupTagRule` | dropped stale key `autoalarm:unhealthy-host-count-anomaly` — no target-group config exists for it |
| remaining 23 rules | byte-identical (patterns, descriptions, targets, MessageGroupIds, DLQ) |

The only other template diffs are the three Lambda `Code` asset hashes, which is synth-to-synth bundling nondeterminism unrelated to this change.

## Tests
- All 8 pre-existing infra tests pass unchanged.
- New: (a) every service event rule has exactly one SQS target with `SqsParameters.MessageGroupId` and a `DeadLetterConfig`; (b) every descriptor rule synthesizes its exact event pattern (arrays matched exactly, so each tag rule's changed-tag-keys list is asserted verbatim) + per-service message group id + DLQ; (c) synthesized service-rule count equals the descriptor table; (d) 11 per-service drift-guard tests against the handler configs.
- `cd cdk && pnpm run build` (prettier + eslint + tsc) ✓, `pnpm test` 22/22 ✓, `cdk synth --quiet` with fake env ✓, `handlers pnpm exec tsc --noEmit` ✓.

## Line delta
`service-eventbridge-subconstruct.ts`: 717 → 434 lines. Overall: +774 / −716 across 4 files (net +58, of which +278 are the new tag-key module and its drift-guard test; the rule wiring itself shrank by ~280 lines).