### PR TITLE
Data-driven event routing registry in main-handler (closes #239)

### DIFF
--- a/handlers/src/event-router.mts
+++ b/handlers/src/event-router.mts
@@ -1,0 +1,483 @@
+import {SQSRecord} from 'aws-lambda';
+import * as ServiceModules from './service-modules/_index.mjs';
+
+/**
+ * Loosely-typed shape of a parsed SQS record body (an EventBridge event).
+ * Only the fields the router inspects are declared; everything else is
+ * carried through untouched.
+ */
+export interface ParsedEventBody {
+  'source'?: string;
+  'detail-type'?: string;
+  'detail'?: {
+    'eventSource'?: string;
+    'eventName'?: string;
+    'resourceType'?: string;
+    'service'?: string;
+    'resource-type'?: string;
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
+/** Predicate evaluated against a parsed event body. */
+export type Matcher = (body: ParsedEventBody) => boolean;
+
+/** Service-module handler invoked with the parsed event body. */
+export type EventHandler = (event: ParsedEventBody) => Promise<unknown>;
+
+/** Service-module handler invoked with the raw SQS record. */
+export type RecordHandler = (record: SQSRecord) => Promise<unknown>;
+
+/** Service-module handler invoked with the raw SQS record and account id. */
+export type RecordAccountHandler = (
+  record: SQSRecord,
+  accountId: string,
+) => Promise<unknown>;
+
+/**
+ * What the main handler should do with a matched event.
+ *
+ * - `module`: await the referenced service-module handler. `args` selects the
+ *   call shape (parsed body, raw SQS record, or record + account id).
+ * - `accumulate-ec2` / `accumulate-ec2-tag`: the main handler appends the
+ *   event to the corresponding deferred-processing array; the post-loop EC2
+ *   batch processing is unchanged.
+ * - `skip`: acknowledge the record without processing. `silent` suppresses
+ *   the warn log for paths that historically dropped the record without
+ *   logging.
+ * - `fail`: log at `level` and report the record as a batch item failure.
+ */
+export type RouteAction =
+  | {kind: 'module'; handler: EventHandler; args: 'body'}
+  | {kind: 'module'; handler: RecordHandler; args: 'record'}
+  | {kind: 'module'; handler: RecordAccountHandler; args: 'record-account'}
+  | {kind: 'accumulate-ec2'}
+  | {kind: 'accumulate-ec2-tag'}
+  | {kind: 'skip'; silent?: boolean; message: (body: ParsedEventBody) => string}
+  | {
+      kind: 'fail';
+      level: 'warn' | 'error';
+      message: (body: ParsedEventBody) => string;
+    };
+
+/** A single entry in the ordered routing registry. */
+export interface RouteEntry {
+  name: string;
+  matches: Matcher;
+  action: RouteAction;
+}
+
+/** The routing outcome for one event: the matched entry name and its action. */
+export interface RouteDecision {
+  name: string;
+  action: RouteAction;
+}
+
+/*
+ * Matcher combinators
+ */
+
+/** Matches when `body.source` is one of the given event sources. */
+export function source(...sources: string[]): Matcher {
+  return (body) =>
+    typeof body.source === 'string' && sources.includes(body.source);
+}
+
+/** Matches when `body['detail-type']` equals the given detail type. */
+export function detailType(type: string): Matcher {
+  return (body) => body['detail-type'] === type;
+}
+
+/** Matches when `body.detail.eventName` is one of the given names. */
+export function eventName(...names: string[]): Matcher {
+  return (body) =>
+    typeof body.detail?.eventName === 'string' &&
+    names.includes(body.detail.eventName);
+}
+
+/** Matches when `body.detail.eventSource` equals the given CloudTrail source. */
+export function eventSource(src: string): Matcher {
+  return (body) => body.detail?.eventSource === src;
+}
+
+/** Matches when `body.detail.resourceType` equals the given type. */
+export function detailResourceType(type: string): Matcher {
+  return (body) => body.detail?.resourceType === type;
+}
+
+/** Matches when `body.detail.resourceType` is present (truthy). */
+export function hasDetailResourceType(): Matcher {
+  return (body) => Boolean(body.detail?.resourceType);
+}
+
+/** Matches when `body.detail.service` (tag events) is one of the given services. */
+export function tagService(...services: string[]): Matcher {
+  return (body) =>
+    typeof body.detail?.service === 'string' &&
+    services.includes(body.detail.service);
+}
+
+/** Matches when `body.detail['resource-type']` (tag events) equals the given type. */
+export function tagResourceType(type: string): Matcher {
+  return (body) => body.detail?.['resource-type'] === type;
+}
+
+/** Matches when every given matcher matches. */
+export function all(...matchers: Matcher[]): Matcher {
+  return (body) => matchers.every((matcher) => matcher(body));
+}
+
+/*
+ * Action helpers
+ */
+
+function module(handler: EventHandler): RouteAction {
+  return {kind: 'module', handler, args: 'body'};
+}
+
+function recordModule(handler: RecordHandler): RouteAction {
+  return {kind: 'module', handler, args: 'record'};
+}
+
+function recordAccountModule(handler: RecordAccountHandler): RouteAction {
+  return {kind: 'module', handler, args: 'record-account'};
+}
+
+/**
+ * Ordered routing registry. The first entry whose matcher returns true wins,
+ * so put more specific matchers before broader fallbacks for the same source.
+ *
+ * Adding a new service is a one-entry change here (plus its service module).
+ */
+export const eventRoutes: RouteEntry[] = [
+  /*
+   * Direct event sources
+   */
+  {
+    name: 'ecs',
+    matches: source('aws.ecs'),
+    action: recordAccountModule(ServiceModules.parseECSEventAndCreateAlarms),
+  },
+  {
+    name: 'log-group',
+    matches: source('aws.logs'),
+    action: recordModule(ServiceModules.parseLogGroupEventAndCreateAlarms),
+  },
+  {
+    name: 'cloudfront',
+    matches: source('aws.cloudfront'),
+    action: module(ServiceModules.parseCloudFrontEventAndCreateAlarms),
+  },
+
+  /*
+   * aws.ec2 — state-change notifications, CloudTrail API calls (which carry
+   * no detail.resourceType), then resourceType-tagged events, then fallbacks.
+   */
+  {
+    name: 'ec2-instance-state-change',
+    matches: all(
+      source('aws.ec2'),
+      detailType('EC2 Instance State-change Notification'),
+    ),
+    action: {kind: 'accumulate-ec2'},
+  },
+  {
+    // CloudTrail VPN events have no detail.resourceType; route by
+    // detail-type, eventSource, and eventName.
+    name: 'ec2-cloudtrail-vpn',
+    matches: all(
+      source('aws.ec2'),
+      detailType('AWS API Call via CloudTrail'),
+      eventSource('ec2.amazonaws.com'),
+      eventName('CreateVpnConnection', 'DeleteVpnConnection'),
+    ),
+    action: module(ServiceModules.parseVpnEventAndCreateAlarms),
+  },
+  {
+    // CloudTrail Transit Gateway events have no detail.resourceType; route by
+    // detail-type, eventSource, and eventName.
+    name: 'ec2-cloudtrail-transit-gateway',
+    matches: all(
+      source('aws.ec2'),
+      detailType('AWS API Call via CloudTrail'),
+      eventSource('ec2.amazonaws.com'),
+      eventName('CreateTransitGateway', 'DeleteTransitGateway'),
+    ),
+    action: module(ServiceModules.parseTransitGatewayEventAndCreateAlarms),
+  },
+  {
+    name: 'ec2-resource-type-instance',
+    matches: all(source('aws.ec2'), detailResourceType('instance')),
+    action: {kind: 'accumulate-ec2'},
+  },
+  {
+    name: 'ec2-resource-type-vpn',
+    matches: all(
+      source('aws.ec2'),
+      detailResourceType('vpn-connection'),
+      eventName('CreateVpnConnection', 'DeleteVpnConnection'),
+    ),
+    action: module(ServiceModules.parseVpnEventAndCreateAlarms),
+  },
+  {
+    // Parity with the old switch: a vpn-connection resourceType with any
+    // other eventName was acknowledged without processing or logging.
+    name: 'ec2-resource-type-vpn-ignored-event-name',
+    matches: all(source('aws.ec2'), detailResourceType('vpn-connection')),
+    action: {
+      kind: 'skip',
+      silent: true,
+      message: (body) =>
+        `Ignoring vpn-connection event with unhandled eventName: ${body.detail?.eventName}`,
+    },
+  },
+  {
+    name: 'ec2-unhandled-resource-type',
+    matches: all(source('aws.ec2'), hasDetailResourceType()),
+    action: {
+      kind: 'fail',
+      level: 'error',
+      message: (body) =>
+        `Unhandled resource type for aws.ec2: ${body.detail?.resourceType}`,
+    },
+  },
+  {
+    name: 'ec2-unhandled-format',
+    matches: source('aws.ec2'),
+    action: {
+      kind: 'fail',
+      level: 'error',
+      message: () => 'Unhandled EC2 event format',
+    },
+  },
+
+  /*
+   * aws.elasticloadbalancing (CloudTrail)
+   */
+  {
+    name: 'elb-load-balancer',
+    matches: all(
+      source('aws.elasticloadbalancing'),
+      eventName('CreateLoadBalancer', 'DeleteLoadBalancer'),
+    ),
+    action: module(ServiceModules.parseALBEventAndCreateAlarms),
+  },
+  {
+    name: 'elb-target-group',
+    matches: all(
+      source('aws.elasticloadbalancing'),
+      eventName('CreateTargetGroup', 'DeleteTargetGroup'),
+    ),
+    action: module(ServiceModules.parseTGEventAndCreateAlarms),
+  },
+  {
+    name: 'elb-unhandled-event-name',
+    matches: source('aws.elasticloadbalancing'),
+    action: {
+      kind: 'fail',
+      level: 'error',
+      message: () => 'Unhandled event name for aws.elasticloadbalancing',
+    },
+  },
+
+  /*
+   * OpenSearch — CloudTrail events arrive with source 'aws.es'
+   */
+  {
+    name: 'opensearch',
+    matches: source('aws.es', 'aws.opensearch'),
+    action: module(ServiceModules.parseOSEventAndCreateAlarms),
+  },
+
+  /*
+   * aws.rds (CloudTrail)
+   */
+  {
+    name: 'rds-instance',
+    matches: all(
+      source('aws.rds'),
+      eventName('CreateDBInstance', 'DeleteDBInstance'),
+    ),
+    action: module(ServiceModules.parseRDSEventAndCreateAlarms),
+  },
+  {
+    name: 'rds-cluster',
+    matches: all(
+      source('aws.rds'),
+      eventName('CreateDBCluster', 'DeleteDBCluster'),
+    ),
+    action: module(ServiceModules.parseRDSClusterEventAndCreateAlarms),
+  },
+  {
+    name: 'rds-unhandled-event-name',
+    matches: source('aws.rds'),
+    action: {
+      kind: 'fail',
+      level: 'error',
+      message: () => 'Unhandled event name for aws.rds',
+    },
+  },
+
+  /*
+   * Remaining direct sources
+   */
+  {
+    name: 'route53-resolver',
+    matches: source('aws.route53resolver'),
+    action: module(ServiceModules.parseR53ResolverEventAndCreateAlarms),
+  },
+  {
+    name: 'sqs',
+    matches: source('aws.sqs'),
+    action: module(ServiceModules.parseSQSEventAndCreateAlarms),
+  },
+  {
+    name: 'step-functions',
+    matches: source('aws.states'),
+    action: module(ServiceModules.parseSFNEventAndCreateAlarms),
+  },
+
+  /*
+   * aws.tag — Tag Change on Resource events, keyed on detail.service and
+   * detail['resource-type']. EC2 instance tag events are accumulated for
+   * deferred batch processing; everything else dispatches directly.
+   */
+  {
+    name: 'tag-ec2-instance',
+    matches: all(
+      source('aws.tag'),
+      tagService('ec2', 'aws.ec2'),
+      tagResourceType('instance'),
+    ),
+    action: {kind: 'accumulate-ec2-tag'},
+  },
+  {
+    // Transit Gateway and VPN tag events arrive with service 'ec2' and are
+    // distinguished by resource-type.
+    name: 'tag-ec2-transit-gateway',
+    matches: all(
+      source('aws.tag'),
+      tagService('ec2'),
+      tagResourceType('transit-gateway'),
+    ),
+    action: module(ServiceModules.parseTransitGatewayEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-ec2-vpn',
+    matches: all(
+      source('aws.tag'),
+      tagService('ec2'),
+      tagResourceType('vpn-connection'),
+    ),
+    action: module(ServiceModules.parseVpnEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-ec2-unhandled-resource-type',
+    matches: all(source('aws.tag'), tagService('ec2')),
+    action: {
+      kind: 'skip',
+      message: (body) =>
+        `Unhandled resource type for EC2: ${body.detail?.['resource-type']}`,
+    },
+  },
+  {
+    name: 'tag-elb-load-balancer',
+    matches: all(
+      source('aws.tag'),
+      tagService('elasticloadbalancing'),
+      tagResourceType('loadbalancer'),
+    ),
+    action: module(ServiceModules.parseALBEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-elb-target-group',
+    matches: all(
+      source('aws.tag'),
+      tagService('elasticloadbalancing'),
+      tagResourceType('targetgroup'),
+    ),
+    action: module(ServiceModules.parseTGEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-elb-unhandled-resource-type',
+    matches: all(source('aws.tag'), tagService('elasticloadbalancing')),
+    action: {
+      kind: 'skip',
+      message: (body) =>
+        `Unhandled resource type for ELB: ${body.detail?.['resource-type']}`,
+    },
+  },
+  {
+    name: 'tag-opensearch',
+    matches: all(source('aws.tag'), tagService('es')),
+    action: module(ServiceModules.parseOSEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-route53-resolver',
+    matches: all(source('aws.tag'), tagService('route53resolver')),
+    action: module(ServiceModules.parseR53ResolverEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-cloudfront',
+    matches: all(source('aws.tag'), tagService('cloudfront')),
+    action: module(ServiceModules.parseCloudFrontEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-rds-cluster',
+    matches: all(
+      source('aws.tag'),
+      tagService('rds'),
+      tagResourceType('cluster'),
+    ),
+    action: module(ServiceModules.parseRDSClusterEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-rds-db',
+    matches: all(source('aws.tag'), tagService('rds'), tagResourceType('db')),
+    action: module(ServiceModules.parseRDSEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-rds-unhandled-resource-type',
+    matches: all(source('aws.tag'), tagService('rds')),
+    action: {
+      kind: 'skip',
+      message: (body) =>
+        `Unhandled RDS resource: ${body.detail?.['resource-type']}`,
+    },
+  },
+  {
+    name: 'tag-step-functions',
+    matches: all(source('aws.tag'), tagService('states')),
+    action: module(ServiceModules.parseSFNEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-unhandled-service',
+    matches: source('aws.tag'),
+    action: {
+      kind: 'skip',
+      message: (body) => `Unhandled service: ${body.detail?.service}`,
+    },
+  },
+];
+
+/**
+ * Routes a parsed event body through the registry. Returns the first matching
+ * entry's decision; events that match no entry fail the record (same outcome
+ * as the old switch's default case).
+ */
+export function routeEvent(body: ParsedEventBody): RouteDecision {
+  for (const entry of eventRoutes) {
+    if (entry.matches(body)) {
+      return {name: entry.name, action: entry.action};
+    }
+  }
+  return {
+    name: 'unhandled-event-source',
+    action: {
+      kind: 'fail',
+      level: 'warn',
+      message: (b) => `Unhandled event source: ${b.source}`,
+    },
+  };
+}

--- a/handlers/src/event-router.test.mts
+++ b/handlers/src/event-router.test.mts
@@ -1,0 +1,449 @@
+import {describe, test, expect} from 'vitest';
+import {routeEvent, ParsedEventBody, RouteDecision} from './event-router.mjs';
+import * as ServiceModules from './service-modules/_index.mjs';
+
+/**
+ * The router is pure: every test builds a synthetic event body shaped like
+ * the real EventBridge events the CDK rules deliver and asserts the routing
+ * decision (action kind and handler reference). Nothing is mocked and no
+ * handler is invoked.
+ */
+
+function tagEvent(
+  service: string,
+  resourceType: string,
+  arn = 'arn:aws:ec2:us-west-2:123456789012:instance/i-0123456789abcdef0',
+): ParsedEventBody {
+  return {
+    'source': 'aws.tag',
+    'detail-type': 'Tag Change on Resource',
+    'resources': [arn],
+    'detail': {
+      'changed-tag-keys': ['autoalarm:enabled'],
+      'service': service,
+      'resource-type': resourceType,
+      'version': 1,
+      'tags': {'autoalarm:enabled': 'true'},
+    },
+  };
+}
+
+function cloudTrailEvent(
+  source: string,
+  eventSource: string,
+  eventName: string,
+  extraDetail: Record<string, unknown> = {},
+): ParsedEventBody {
+  return {
+    'source': source,
+    'detail-type': 'AWS API Call via CloudTrail',
+    'detail': {
+      eventSource: eventSource,
+      eventName: eventName,
+      awsRegion: 'us-west-2',
+      ...extraDetail,
+    },
+  };
+}
+
+function expectModule(
+  decision: RouteDecision,
+  handler: unknown,
+  args: 'body' | 'record' | 'record-account' = 'body',
+) {
+  expect(decision.action.kind).toBe('module');
+  if (decision.action.kind === 'module') {
+    expect(decision.action.handler).toBe(handler);
+    expect(decision.action.args).toBe(args);
+  }
+}
+
+describe('direct event sources', () => {
+  test('aws.ecs routes to the ECS module with record and account id', () => {
+    const decision = routeEvent({
+      'source': 'aws.ecs',
+      'detail-type': 'ECS Service Action',
+      'detail': {eventName: 'SERVICE_STEADY_STATE'},
+    });
+    expect(decision.name).toBe('ecs');
+    expectModule(
+      decision,
+      ServiceModules.parseECSEventAndCreateAlarms,
+      'record-account',
+    );
+  });
+
+  test('aws.logs routes to the log group module with the raw record', () => {
+    const decision = routeEvent(
+      cloudTrailEvent('aws.logs', 'logs.amazonaws.com', 'CreateLogGroup', {
+        requestParameters: {logGroupName: '/aws/lambda/my-function'},
+      }),
+    );
+    expect(decision.name).toBe('log-group');
+    expectModule(
+      decision,
+      ServiceModules.parseLogGroupEventAndCreateAlarms,
+      'record',
+    );
+  });
+
+  test('aws.cloudfront routes to the CloudFront module', () => {
+    const decision = routeEvent(
+      cloudTrailEvent(
+        'aws.cloudfront',
+        'cloudfront.amazonaws.com',
+        'CreateDistribution',
+      ),
+    );
+    expect(decision.name).toBe('cloudfront');
+    expectModule(decision, ServiceModules.parseCloudFrontEventAndCreateAlarms);
+  });
+
+  test('aws.es and aws.opensearch route to the OpenSearch module', () => {
+    for (const src of ['aws.es', 'aws.opensearch']) {
+      const decision = routeEvent(
+        cloudTrailEvent(src, 'es.amazonaws.com', 'CreateDomain'),
+      );
+      expect(decision.name).toBe('opensearch');
+      expectModule(decision, ServiceModules.parseOSEventAndCreateAlarms);
+    }
+  });
+
+  test('aws.route53resolver routes to the Route53 resolver module', () => {
+    const decision = routeEvent(
+      cloudTrailEvent(
+        'aws.route53resolver',
+        'route53resolver.amazonaws.com',
+        'CreateResolverEndpoint',
+      ),
+    );
+    expect(decision.name).toBe('route53-resolver');
+    expectModule(decision, ServiceModules.parseR53ResolverEventAndCreateAlarms);
+  });
+
+  test('aws.sqs routes to the SQS module', () => {
+    const decision = routeEvent(
+      cloudTrailEvent('aws.sqs', 'sqs.amazonaws.com', 'CreateQueue'),
+    );
+    expect(decision.name).toBe('sqs');
+    expectModule(decision, ServiceModules.parseSQSEventAndCreateAlarms);
+  });
+
+  test('aws.states routes to the Step Functions module', () => {
+    const decision = routeEvent(
+      cloudTrailEvent(
+        'aws.states',
+        'states.amazonaws.com',
+        'CreateStateMachine',
+      ),
+    );
+    expect(decision.name).toBe('step-functions');
+    expectModule(decision, ServiceModules.parseSFNEventAndCreateAlarms);
+  });
+});
+
+describe('aws.ec2 events', () => {
+  test('instance state-change notification is accumulated for batch processing', () => {
+    const decision = routeEvent({
+      'source': 'aws.ec2',
+      'detail-type': 'EC2 Instance State-change Notification',
+      'detail': {'instance-id': 'i-0123456789abcdef0', 'state': 'running'},
+    });
+    expect(decision.name).toBe('ec2-instance-state-change');
+    expect(decision.action.kind).toBe('accumulate-ec2');
+  });
+
+  test('CloudTrail VPN event without detail.resourceType routes to the VPN module', () => {
+    // The old bug class: CloudTrail events carry no detail.resourceType and
+    // each needed a hand-written special case (VPN: 9239dc8).
+    for (const name of ['CreateVpnConnection', 'DeleteVpnConnection']) {
+      const decision = routeEvent(
+        cloudTrailEvent('aws.ec2', 'ec2.amazonaws.com', name, {
+          responseElements: {vpnConnection: {vpnConnectionId: 'vpn-123'}},
+        }),
+      );
+      expect(decision.name).toBe('ec2-cloudtrail-vpn');
+      expectModule(decision, ServiceModules.parseVpnEventAndCreateAlarms);
+    }
+  });
+
+  test('CloudTrail Transit Gateway event without detail.resourceType routes to the TGW module', () => {
+    // The old bug class: the identical Transit Gateway gap was open until #226.
+    for (const name of ['CreateTransitGateway', 'DeleteTransitGateway']) {
+      const decision = routeEvent(
+        cloudTrailEvent('aws.ec2', 'ec2.amazonaws.com', name, {
+          responseElements: {transitGateway: {transitGatewayId: 'tgw-123'}},
+        }),
+      );
+      expect(decision.name).toBe('ec2-cloudtrail-transit-gateway');
+      expectModule(
+        decision,
+        ServiceModules.parseTransitGatewayEventAndCreateAlarms,
+      );
+    }
+  });
+
+  test('event with detail.resourceType instance is accumulated for batch processing', () => {
+    const decision = routeEvent({
+      source: 'aws.ec2',
+      detail: {resourceType: 'instance', eventName: 'RunInstances'},
+    });
+    expect(decision.name).toBe('ec2-resource-type-instance');
+    expect(decision.action.kind).toBe('accumulate-ec2');
+  });
+
+  test('vpn-connection resourceType with a VPN eventName routes to the VPN module', () => {
+    const decision = routeEvent({
+      source: 'aws.ec2',
+      detail: {
+        resourceType: 'vpn-connection',
+        eventName: 'CreateVpnConnection',
+      },
+    });
+    expect(decision.name).toBe('ec2-resource-type-vpn');
+    expectModule(decision, ServiceModules.parseVpnEventAndCreateAlarms);
+  });
+
+  test('vpn-connection resourceType with another eventName is skipped (acked, not failed)', () => {
+    const decision = routeEvent({
+      source: 'aws.ec2',
+      detail: {
+        resourceType: 'vpn-connection',
+        eventName: 'ModifyVpnConnection',
+      },
+    });
+    expect(decision.name).toBe('ec2-resource-type-vpn-ignored-event-name');
+    expect(decision.action.kind).toBe('skip');
+  });
+
+  test('unknown detail.resourceType fails the record', () => {
+    const body: ParsedEventBody = {
+      source: 'aws.ec2',
+      detail: {resourceType: 'volume', eventName: 'CreateVolume'},
+    };
+    const decision = routeEvent(body);
+    expect(decision.name).toBe('ec2-unhandled-resource-type');
+    expect(decision.action.kind).toBe('fail');
+    if (decision.action.kind === 'fail') {
+      expect(decision.action.level).toBe('error');
+      expect(decision.action.message(body)).toBe(
+        'Unhandled resource type for aws.ec2: volume',
+      );
+    }
+  });
+
+  test('CloudTrail event with an unhandled eventName and no resourceType fails the record', () => {
+    const decision = routeEvent(
+      cloudTrailEvent('aws.ec2', 'ec2.amazonaws.com', 'CreateVolume'),
+    );
+    expect(decision.name).toBe('ec2-unhandled-format');
+    expect(decision.action.kind).toBe('fail');
+  });
+
+  test('aws.ec2 event with no detail at all fails the record', () => {
+    const decision = routeEvent({source: 'aws.ec2'});
+    expect(decision.name).toBe('ec2-unhandled-format');
+    expect(decision.action.kind).toBe('fail');
+  });
+});
+
+describe('aws.elasticloadbalancing events', () => {
+  test('load balancer create/delete routes to the ALB module', () => {
+    for (const name of ['CreateLoadBalancer', 'DeleteLoadBalancer']) {
+      const decision = routeEvent(
+        cloudTrailEvent(
+          'aws.elasticloadbalancing',
+          'elasticloadbalancing.amazonaws.com',
+          name,
+        ),
+      );
+      expect(decision.name).toBe('elb-load-balancer');
+      expectModule(decision, ServiceModules.parseALBEventAndCreateAlarms);
+    }
+  });
+
+  test('target group create/delete routes to the target group module', () => {
+    for (const name of ['CreateTargetGroup', 'DeleteTargetGroup']) {
+      const decision = routeEvent(
+        cloudTrailEvent(
+          'aws.elasticloadbalancing',
+          'elasticloadbalancing.amazonaws.com',
+          name,
+        ),
+      );
+      expect(decision.name).toBe('elb-target-group');
+      expectModule(decision, ServiceModules.parseTGEventAndCreateAlarms);
+    }
+  });
+
+  test('unhandled eventName fails the record', () => {
+    const decision = routeEvent(
+      cloudTrailEvent(
+        'aws.elasticloadbalancing',
+        'elasticloadbalancing.amazonaws.com',
+        'ModifyLoadBalancerAttributes',
+      ),
+    );
+    expect(decision.name).toBe('elb-unhandled-event-name');
+    expect(decision.action.kind).toBe('fail');
+  });
+});
+
+describe('aws.rds events', () => {
+  test('DB instance create/delete routes to the RDS module', () => {
+    for (const name of ['CreateDBInstance', 'DeleteDBInstance']) {
+      const decision = routeEvent(
+        cloudTrailEvent('aws.rds', 'rds.amazonaws.com', name),
+      );
+      expect(decision.name).toBe('rds-instance');
+      expectModule(decision, ServiceModules.parseRDSEventAndCreateAlarms);
+    }
+  });
+
+  test('DB cluster create/delete routes to the RDS cluster module', () => {
+    for (const name of ['CreateDBCluster', 'DeleteDBCluster']) {
+      const decision = routeEvent(
+        cloudTrailEvent('aws.rds', 'rds.amazonaws.com', name),
+      );
+      expect(decision.name).toBe('rds-cluster');
+      expectModule(
+        decision,
+        ServiceModules.parseRDSClusterEventAndCreateAlarms,
+      );
+    }
+  });
+
+  test('unhandled eventName fails the record', () => {
+    const decision = routeEvent(
+      cloudTrailEvent('aws.rds', 'rds.amazonaws.com', 'ModifyDBInstance'),
+    );
+    expect(decision.name).toBe('rds-unhandled-event-name');
+    expect(decision.action.kind).toBe('fail');
+  });
+});
+
+describe('aws.tag events', () => {
+  test('EC2 instance tag events (service ec2 or aws.ec2) are accumulated', () => {
+    for (const service of ['ec2', 'aws.ec2']) {
+      const decision = routeEvent(tagEvent(service, 'instance'));
+      expect(decision.name).toBe('tag-ec2-instance');
+      expect(decision.action.kind).toBe('accumulate-ec2-tag');
+    }
+  });
+
+  test('transit-gateway tag events route to the TGW module', () => {
+    const decision = routeEvent(tagEvent('ec2', 'transit-gateway'));
+    expect(decision.name).toBe('tag-ec2-transit-gateway');
+    expectModule(
+      decision,
+      ServiceModules.parseTransitGatewayEventAndCreateAlarms,
+    );
+  });
+
+  test('vpn-connection tag events route to the VPN module', () => {
+    const decision = routeEvent(tagEvent('ec2', 'vpn-connection'));
+    expect(decision.name).toBe('tag-ec2-vpn');
+    expectModule(decision, ServiceModules.parseVpnEventAndCreateAlarms);
+  });
+
+  test('unhandled ec2 tag resource-type is skipped with a warning', () => {
+    const decision = routeEvent(tagEvent('ec2', 'security-group'));
+    expect(decision.name).toBe('tag-ec2-unhandled-resource-type');
+    expect(decision.action.kind).toBe('skip');
+  });
+
+  test('elasticloadbalancing tag events route by resource-type', () => {
+    const lb = routeEvent(tagEvent('elasticloadbalancing', 'loadbalancer'));
+    expect(lb.name).toBe('tag-elb-load-balancer');
+    expectModule(lb, ServiceModules.parseALBEventAndCreateAlarms);
+
+    const tg = routeEvent(tagEvent('elasticloadbalancing', 'targetgroup'));
+    expect(tg.name).toBe('tag-elb-target-group');
+    expectModule(tg, ServiceModules.parseTGEventAndCreateAlarms);
+
+    const other = routeEvent(tagEvent('elasticloadbalancing', 'listener'));
+    expect(other.name).toBe('tag-elb-unhandled-resource-type');
+    expect(other.action.kind).toBe('skip');
+  });
+
+  test('es tag events route to the OpenSearch module', () => {
+    const decision = routeEvent(tagEvent('es', 'domain'));
+    expect(decision.name).toBe('tag-opensearch');
+    expectModule(decision, ServiceModules.parseOSEventAndCreateAlarms);
+  });
+
+  test('route53resolver tag events route to the resolver module', () => {
+    const decision = routeEvent(
+      tagEvent('route53resolver', 'resolver-endpoint'),
+    );
+    expect(decision.name).toBe('tag-route53-resolver');
+    expectModule(decision, ServiceModules.parseR53ResolverEventAndCreateAlarms);
+  });
+
+  test('cloudfront tag events route to the CloudFront module', () => {
+    const decision = routeEvent(tagEvent('cloudfront', 'distribution'));
+    expect(decision.name).toBe('tag-cloudfront');
+    expectModule(decision, ServiceModules.parseCloudFrontEventAndCreateAlarms);
+  });
+
+  test('rds tag events route by resource-type', () => {
+    const cluster = routeEvent(tagEvent('rds', 'cluster'));
+    expect(cluster.name).toBe('tag-rds-cluster');
+    expectModule(cluster, ServiceModules.parseRDSClusterEventAndCreateAlarms);
+
+    const db = routeEvent(tagEvent('rds', 'db'));
+    expect(db.name).toBe('tag-rds-db');
+    expectModule(db, ServiceModules.parseRDSEventAndCreateAlarms);
+
+    const other = routeEvent(tagEvent('rds', 'snapshot'));
+    expect(other.name).toBe('tag-rds-unhandled-resource-type');
+    expect(other.action.kind).toBe('skip');
+  });
+
+  test('states tag events route to the Step Functions module', () => {
+    const decision = routeEvent(tagEvent('states', 'stateMachine'));
+    expect(decision.name).toBe('tag-step-functions');
+    expectModule(decision, ServiceModules.parseSFNEventAndCreateAlarms);
+  });
+
+  test('tag events for an unhandled service are skipped with a warning', () => {
+    const decision = routeEvent(tagEvent('lambda', 'function'));
+    expect(decision.name).toBe('tag-unhandled-service');
+    expect(decision.action.kind).toBe('skip');
+  });
+
+  test('parity quirk: service aws.ec2 with non-instance resource-type falls through to unhandled service', () => {
+    // The old routeTagEvent only matched service === 'ec2'; 'aws.ec2' was
+    // only honored for instance tag events, everything else hit the default.
+    const decision = routeEvent(tagEvent('aws.ec2', 'transit-gateway'));
+    expect(decision.name).toBe('tag-unhandled-service');
+    expect(decision.action.kind).toBe('skip');
+  });
+});
+
+describe('unmatched events', () => {
+  test('unknown source produces a failure decision (warn + batch item failure)', () => {
+    const decision = routeEvent({
+      'source': 'aws.lambda',
+      'detail-type': 'AWS API Call via CloudTrail',
+      'detail': {
+        eventSource: 'lambda.amazonaws.com',
+        eventName: 'CreateFunction',
+      },
+    });
+    expect(decision.name).toBe('unhandled-event-source');
+    expect(decision.action.kind).toBe('fail');
+    if (decision.action.kind === 'fail') {
+      expect(decision.action.level).toBe('warn');
+      expect(decision.action.message({source: 'aws.lambda'})).toBe(
+        'Unhandled event source: aws.lambda',
+      );
+    }
+  });
+
+  test('body without a source produces a failure decision', () => {
+    const decision = routeEvent({detail: {eventName: 'Anything'}});
+    expect(decision.name).toBe('unhandled-event-source');
+    expect(decision.action.kind).toBe('fail');
+  });
+});

--- a/handlers/src/main-handler.mts
+++ b/handlers/src/main-handler.mts
@@ -7,6 +7,7 @@ import {
 } from 'aws-lambda';
 import * as logging from '@nr1e/logging';
 import * as ServiceModules from './service-modules/_index.mjs';
+import {routeEvent} from './event-router.mjs';
 import {EC2AlarmManagerArray} from './types/index.mjs';
 
 // Initialize logging
@@ -215,97 +216,6 @@ async function processEC2TagEvent(
   return failedRecords;
 }
 
-// TODO Fix the use of any
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function routeTagEvent(event: any) {
-  const detail = event.detail;
-  const resourceType = detail['resource-type'];
-  const service = detail.service;
-
-  log
-    .info()
-    .str('function', 'routeTagEvent')
-    .str('resourceType', resourceType)
-    .str('service', service)
-    .msg('Processing tag event');
-
-  switch (service) {
-    // Transit Gateway and VPN tag events arrive with service 'ec2' and are
-    // distinguished by resource-type. EC2 instance tag events are diverted
-    // before routeTagEvent is called.
-    case 'ec2':
-      switch (resourceType) {
-        case 'transit-gateway':
-          await ServiceModules.parseTransitGatewayEventAndCreateAlarms(event);
-          break;
-
-        case 'vpn-connection':
-          await ServiceModules.parseVpnEventAndCreateAlarms(event);
-          break;
-
-        default:
-          log
-            .warn()
-            .str('function', 'routeTagEvent')
-            .msg(`Unhandled resource type for EC2: ${resourceType}`);
-          break;
-      }
-      break;
-
-    case 'elasticloadbalancing':
-      switch (resourceType) {
-        case 'loadbalancer':
-          await ServiceModules.parseALBEventAndCreateAlarms(event);
-          break;
-
-        case 'targetgroup':
-          await ServiceModules.parseTGEventAndCreateAlarms(event);
-          break;
-
-        default:
-          log
-            .warn()
-            .str('function', 'routeTagEvent')
-            .msg(`Unhandled resource type for ELB: ${resourceType}`);
-          break;
-      }
-      break;
-
-    case 'es':
-      await ServiceModules.parseOSEventAndCreateAlarms(event);
-      break;
-
-    case 'route53resolver':
-      await ServiceModules.parseR53ResolverEventAndCreateAlarms(event);
-      break;
-
-    case 'cloudfront':
-      await ServiceModules.parseCloudFrontEventAndCreateAlarms(event);
-      break;
-
-    case 'rds':
-      if (resourceType === 'cluster') {
-        await ServiceModules.parseRDSClusterEventAndCreateAlarms(event);
-      } else if (resourceType === 'db') {
-        await ServiceModules.parseRDSEventAndCreateAlarms(event);
-      } else {
-        log.warn().msg(`Unhandled RDS resource: ${resourceType}`);
-      }
-      break;
-
-    case 'states':
-      await ServiceModules.parseSFNEventAndCreateAlarms(event);
-      break;
-
-    default:
-      log
-        .warn()
-        .str('function', 'routeTagEvent')
-        .msg(`Unhandled service: ${service}`);
-      break;
-  }
-}
-
 export const handler: Handler = async (
   event: SQSEvent,
 ): Promise<void | SQSBatchResponse> => {
@@ -361,160 +271,54 @@ export const handler: Handler = async (
     log.trace().obj('body', parsedBody).msg('Processing message body');
 
     try {
-      // TODO Fix the ugliness below. Future modules should be simple if statements
-      if (parsedBody.source === 'aws.ecs') {
-        await ServiceModules.parseECSEventAndCreateAlarms(
-          record,
-          process.env.ACCT_ID!,
-        );
-        continue;
-      }
+      const {name, action} = routeEvent(parsedBody);
 
-      if (parsedBody.source === 'aws.logs') {
-        await ServiceModules.parseLogGroupEventAndCreateAlarms(record);
-        continue;
-      }
+      log
+        .debug()
+        .str('function', 'handler')
+        .str('route', name)
+        .str('source', parsedBody.source)
+        .str('messageId', record.messageId)
+        .msg('Matched route entry');
 
-      switch (parsedBody.source) {
-        case 'aws.cloudfront':
-          await ServiceModules.parseCloudFrontEventAndCreateAlarms(parsedBody);
-          break;
-        case 'aws.ec2':
-          log
-            .debug()
-            .str('function', 'handler')
-            .obj('eventDetail', parsedBody.detail)
-            .str('resourceType', JSON.stringify(parsedBody.detail))
-            .msg('Processing EC2 event');
-
-          // Check for EC2 Instance State-change Notification based on detail-type
-          if (
-            parsedBody['detail-type'] ===
-            'EC2 Instance State-change Notification'
-          ) {
-            ec2Events.push({event: parsedBody, record: record});
-          } else if (
-            parsedBody.detail &&
-            parsedBody['detail-type'] === 'AWS API Call via CloudTrail' &&
-            parsedBody.detail.eventSource === 'ec2.amazonaws.com' &&
-            (parsedBody.detail.eventName === 'CreateVpnConnection' ||
-              parsedBody.detail.eventName === 'DeleteVpnConnection')
-          ) {
-            // CloudTrail VPN events have no detail.resourceType; route by detail-type and eventName
-            await ServiceModules.parseVpnEventAndCreateAlarms(parsedBody);
-          } else if (
-            parsedBody.detail &&
-            parsedBody['detail-type'] === 'AWS API Call via CloudTrail' &&
-            parsedBody.detail.eventSource === 'ec2.amazonaws.com' &&
-            (parsedBody.detail.eventName === 'CreateTransitGateway' ||
-              parsedBody.detail.eventName === 'DeleteTransitGateway')
-          ) {
-            // CloudTrail Transit Gateway events have no detail.resourceType; route by detail-type and eventName
-            await ServiceModules.parseTransitGatewayEventAndCreateAlarms(
-              parsedBody,
-            );
-          } else if (parsedBody.detail && parsedBody.detail.resourceType) {
-            // Handle other EC2 events that have a resourceType defined
-            switch (parsedBody.detail.resourceType) {
-              case 'instance':
-                ec2Events.push({event: parsedBody, record: record});
-                break;
-              case 'vpn-connection':
-                if (
-                  parsedBody.detail.eventName === 'CreateVpnConnection' ||
-                  parsedBody.detail.eventName === 'DeleteVpnConnection'
-                )
-                  await ServiceModules.parseVpnEventAndCreateAlarms(parsedBody);
-                break;
-              default:
-                log
-                  .error()
-                  .msg(
-                    `Unhandled resource type for aws.ec2: ${parsedBody.detail.resourceType}`,
-                  );
-                batchItemFailures.push({itemIdentifier: record.messageId});
-                batchItemBodies.push(record);
-                break;
-            }
+      switch (action.kind) {
+        case 'module':
+          if (action.args === 'record-account') {
+            await action.handler(record, process.env.ACCT_ID!);
+          } else if (action.args === 'record') {
+            await action.handler(record);
           } else {
-            log.error().msg('Unhandled EC2 event format');
-            batchItemFailures.push({itemIdentifier: record.messageId});
-            batchItemBodies.push(record);
+            await action.handler(parsedBody);
           }
           break;
-        case 'aws.elasticloadbalancing':
-          if (
-            parsedBody.detail.eventName === 'CreateLoadBalancer' ||
-            parsedBody.detail.eventName === 'DeleteLoadBalancer'
-          ) {
-            await ServiceModules.parseALBEventAndCreateAlarms(parsedBody);
-          } else if (
-            parsedBody.detail.eventName === 'CreateTargetGroup' ||
-            parsedBody.detail.eventName === 'DeleteTargetGroup'
-          ) {
-            await ServiceModules.parseTGEventAndCreateAlarms(parsedBody);
-          } else {
+
+        case 'accumulate-ec2':
+          // EC2 instance events are accumulated and processed in one batch
+          // after the loop (see processEC2Event).
+          ec2Events.push({event: parsedBody, record: record});
+          break;
+
+        case 'accumulate-ec2-tag':
+          // EC2 instance tag events are accumulated and processed in one
+          // batch after the loop (see processEC2TagEvent).
+          ec2TagEvents.push({event: parsedBody, record: record});
+          break;
+
+        case 'skip':
+          if (!action.silent) {
             log
-              .error()
-              .msg('Unhandled event name for aws.elasticloadbalancing');
-            batchItemFailures.push({itemIdentifier: record.messageId});
-            batchItemBodies.push(record);
+              .warn()
+              .str('function', 'handler')
+              .str('route', name)
+              .msg(action.message(parsedBody));
           }
           break;
 
-        // OpenSearch CloudTrail events arrive with source 'aws.es'
-        case 'aws.es':
-        case 'aws.opensearch':
-          await ServiceModules.parseOSEventAndCreateAlarms(parsedBody);
-          break;
-
-        case 'aws.rds':
-          if (
-            parsedBody.detail.eventName === 'CreateDBInstance' ||
-            parsedBody.detail.eventName === 'DeleteDBInstance'
-          ) {
-            await ServiceModules.parseRDSEventAndCreateAlarms(parsedBody);
-          } else if (
-            parsedBody.detail.eventName === 'CreateDBCluster' ||
-            parsedBody.detail.eventName === 'DeleteDBCluster'
-          ) {
-            await ServiceModules.parseRDSClusterEventAndCreateAlarms(
-              parsedBody,
-            );
-          } else {
-            log.error().msg('Unhandled event name for aws.rds');
-            batchItemFailures.push({itemIdentifier: record.messageId});
-            batchItemBodies.push(record);
-          }
-          break;
-
-        case 'aws.route53resolver':
-          await ServiceModules.parseR53ResolverEventAndCreateAlarms(parsedBody);
-          break;
-
-        case 'aws.sqs':
-          await ServiceModules.parseSQSEventAndCreateAlarms(parsedBody);
-          break;
-
-        case 'aws.states':
-          await ServiceModules.parseSFNEventAndCreateAlarms(parsedBody);
-          break;
-
-        case 'aws.tag':
-          // add ec2 tag events to another array for processing.
-          if (
-            (parsedBody.detail.service === 'ec2' ||
-              parsedBody.detail.service === 'aws.ec2') &&
-            parsedBody.detail['resource-type'] === 'instance'
-          ) {
-            ec2TagEvents.push({event: parsedBody, record: record});
-          } else {
-            await routeTagEvent(parsedBody);
-          }
-          break;
-
-        default:
-          log.warn().msg(`Unhandled event source: ${parsedBody.source}`);
+        case 'fail':
+          log[action.level]()
+            .str('function', 'handler')
+            .str('route', name)
+            .msg(action.message(parsedBody));
           batchItemFailures.push({itemIdentifier: record.messageId});
           batchItemBodies.push(record);
           break;


### PR DESCRIPTION
Closes #239 (from the 2026-06-10 comprehensive code review, Set 10.1).

## Registry design

`handlers/src/event-router.mts` introduces an **ordered routing registry**: an array of `{name, matches, action}` entries built from small declarative matcher combinators (`source(...)`, `detailType(t)`, `eventName(...)`, `eventSource(s)`, `detailResourceType(rt)`, `hasDetailResourceType()`, `tagService(...)`, `tagResourceType(rt)`, `all(...)`). `routeEvent(parsedBody)` returns the first matching entry's decision; the router is **pure** (no logging, no I/O, no awaits), so it is trivially unit-testable.

Action kinds:

- `module` — main-handler awaits the referenced service-module handler; `args` selects the call shape (`body`, `record`, or `record-account` for ECS).
- `accumulate-ec2` / `accumulate-ec2-tag` — the router only returns the decision; main-handler performs the accumulation, so the **post-loop batched EC2 processing (`processEC2Event` / `processEC2TagEvent`) is untouched**.
- `skip` — acknowledge without processing (warn log; `silent` preserves the one path that historically dropped without logging).
- `fail` — log at the original level and report the record as a batch item failure.
- Unmatched events get the same default as the old `switch`: warn `Unhandled event source: X` + batch item failure.

`main-handler.mts` per-record body is now parse → `routeEvent` → execute decision, inside the existing try/catch + `batchItemFailures` plumbing. `routeTagEvent` and both nested switches are deleted. The `errorMessage` envelope skip, EC2 post-loop processing, and per-record failure attribution are unchanged.

**This kills the CloudTrail special-case bug class**: CloudTrail events carry no `detail.resourceType`, which forced the hand-written VPN special case (9239dc8) and left the identical Transit Gateway gap open until #226. Both are now ordinary registry entries matched on `detail-type` + `eventSource` + `eventName`. **Adding a service = one registry entry** (plus its service module).

## Path-parity table (old switch path → registry entry)

| Old path | Registry entry | Action |
|---|---|---|
| `if source === 'aws.ecs'` | `ecs` | module `parseECSEventAndCreateAlarms(record, ACCT_ID)` |
| `if source === 'aws.logs'` | `log-group` | module `parseLogGroupEventAndCreateAlarms(record)` |
| `case 'aws.cloudfront'` | `cloudfront` | module `parseCloudFrontEventAndCreateAlarms` |
| `aws.ec2` + detail-type `EC2 Instance State-change Notification` | `ec2-instance-state-change` | accumulate-ec2 |
| `aws.ec2` + CloudTrail + `Create/DeleteVpnConnection` (no resourceType — 9239dc8 special case) | `ec2-cloudtrail-vpn` | module `parseVpnEventAndCreateAlarms` |
| `aws.ec2` + CloudTrail + `Create/DeleteTransitGateway` (no resourceType — #226 special case) | `ec2-cloudtrail-transit-gateway` | module `parseTransitGatewayEventAndCreateAlarms` |
| `aws.ec2` + `detail.resourceType === 'instance'` | `ec2-resource-type-instance` | accumulate-ec2 |
| `aws.ec2` + resourceType `vpn-connection` + VPN eventName | `ec2-resource-type-vpn` | module `parseVpnEventAndCreateAlarms` |
| `aws.ec2` + resourceType `vpn-connection`, other eventName (silently acked) | `ec2-resource-type-vpn-ignored-event-name` | skip (silent, parity) |
| `aws.ec2` + other resourceType | `ec2-unhandled-resource-type` | fail (error) |
| `aws.ec2`, no matching shape | `ec2-unhandled-format` | fail (error) |
| `aws.elasticloadbalancing` + `Create/DeleteLoadBalancer` | `elb-load-balancer` | module `parseALBEventAndCreateAlarms` |
| `aws.elasticloadbalancing` + `Create/DeleteTargetGroup` | `elb-target-group` | module `parseTGEventAndCreateAlarms` |
| `aws.elasticloadbalancing`, other eventName | `elb-unhandled-event-name` | fail (error) |
| `case 'aws.es'` / `'aws.opensearch'` | `opensearch` | module `parseOSEventAndCreateAlarms` |
| `aws.rds` + `Create/DeleteDBInstance` | `rds-instance` | module `parseRDSEventAndCreateAlarms` |
| `aws.rds` + `Create/DeleteDBCluster` | `rds-cluster` | module `parseRDSClusterEventAndCreateAlarms` |
| `aws.rds`, other eventName | `rds-unhandled-event-name` | fail (error) |
| `case 'aws.route53resolver'` | `route53-resolver` | module `parseR53ResolverEventAndCreateAlarms` |
| `case 'aws.sqs'` | `sqs` | module `parseSQSEventAndCreateAlarms` |
| `case 'aws.states'` | `step-functions` | module `parseSFNEventAndCreateAlarms` |
| `aws.tag` + service `ec2`/`aws.ec2` + resource-type `instance` | `tag-ec2-instance` | accumulate-ec2-tag |
| routeTagEvent `ec2`/`transit-gateway` | `tag-ec2-transit-gateway` | module `parseTransitGatewayEventAndCreateAlarms` |
| routeTagEvent `ec2`/`vpn-connection` | `tag-ec2-vpn` | module `parseVpnEventAndCreateAlarms` |
| routeTagEvent `ec2`/other (warn + ack) | `tag-ec2-unhandled-resource-type` | skip (warn) |
| routeTagEvent `elasticloadbalancing`/`loadbalancer` | `tag-elb-load-balancer` | module `parseALBEventAndCreateAlarms` |
| routeTagEvent `elasticloadbalancing`/`targetgroup` | `tag-elb-target-group` | module `parseTGEventAndCreateAlarms` |
| routeTagEvent `elasticloadbalancing`/other (warn + ack) | `tag-elb-unhandled-resource-type` | skip (warn) |
| routeTagEvent `es` | `tag-opensearch` | module `parseOSEventAndCreateAlarms` |
| routeTagEvent `route53resolver` | `tag-route53-resolver` | module `parseR53ResolverEventAndCreateAlarms` |
| routeTagEvent `cloudfront` | `tag-cloudfront` | module `parseCloudFrontEventAndCreateAlarms` |
| routeTagEvent `rds`/`cluster` | `tag-rds-cluster` | module `parseRDSClusterEventAndCreateAlarms` |
| routeTagEvent `rds`/`db` | `tag-rds-db` | module `parseRDSEventAndCreateAlarms` |
| routeTagEvent `rds`/other (warn + ack) | `tag-rds-unhandled-resource-type` | skip (warn) |
| routeTagEvent `states` | `tag-step-functions` | module `parseSFNEventAndCreateAlarms` |
| routeTagEvent default (warn + ack) | `tag-unhandled-service` | skip (warn) |
| outer `default` (warn + batch item failure) | unmatched → `unhandled-event-source` | fail (warn) |

Parity quirk preserved (and pinned by a test): `aws.tag` with service `aws.ec2` and a non-`instance` resource-type falls through to `tag-unhandled-service`, exactly as the old `routeTagEvent` (which only matched service `'ec2'`) did.

## Test coverage

`handlers/src/event-router.test.mts` — 36 new pure-router tests, nothing mocked; assertions compare decision kinds and service-module handler references using realistic EventBridge/CloudTrail/tag-change event shapes:

- one representative event per registry entry (all 36 entries covered),
- the old bug class as negative tests: CloudTrail VPN and Transit Gateway events **without** `detail.resourceType` route to the right modules; an aws.ec2 CloudTrail event with an unhandled eventName falls to `ec2-unhandled-format`,
- unknown source and missing source → failure decision (warn + batch item failure).

## Verification

- `handlers`: `tsc --noEmit` clean, `eslint .` clean, `prettier --check .` clean, `vitest run --coverage`: **57 tests passed** (21 existing + 36 new)
- `cdk`: `pnpm run build` clean, `pnpm test`: **8 passed**