### PR TITLE
ReAlarm: bulk tag pre-filter via Resource Groups Tagging API (closes #238)

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,6 +423,9 @@ ReAlarm's behavior can be configured on a per-alarm basis using tags.
     - Alarms can be tagged with `autoalarm:re-alarm-enabled=false` to exclude them from the ReAlarm process.
     - When this tag is present on an alarm, ReAlarm will skip resetting it, regardless of its state.
     - This is useful for alarms that should be managed manually or have specific conditions that should not trigger ReAlarm.
+    - ReAlarm discovers these tags in bulk via the Resource Groups Tagging API, whose data is eventually consistent —
+      a tag added or removed shortly before a scheduled run may not take effect until the next cycle (typically within
+      minutes).
 
 **Example**
 

--- a/cdk/lib/realarm-consumer-subconstruct.ts
+++ b/cdk/lib/realarm-consumer-subconstruct.ts
@@ -100,7 +100,7 @@ export class ReAlarmConsumer extends Construct {
   private createRole(reAlarmConsumerQueueArn: string): IRole {
     /**
      * Set up the IAM roles for the ReAlarm Consumer function
-     * Allow the consumer to describe alarms and list tags
+     * Allow the consumer to describe alarms
      * Allow the consumer to set alarm state
      * Allow the consumer to write to CloudWatch Logs
      * Allow Consumer to consume messages from the Consumer queue
@@ -128,15 +128,14 @@ export class ReAlarmConsumer extends Construct {
       }),
     );
 
-    // DescribeAlarms and ListTagsForResource are read/list operations that
-    // must run against all alarms in the account.
+    // DescribeAlarms is a read/list operation that must run against all
+    // alarms in the account. ListTagsForResource is no longer needed: the
+    // producer resolves all tag-derived facts (bulk Tagging API sweep /
+    // single-alarm lookup) and embeds them in each SQS message.
     reAlarmConsumerRole.addToPolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
-        actions: [
-          'cloudwatch:DescribeAlarms',
-          'cloudwatch:ListTagsForResource',
-        ],
+        actions: ['cloudwatch:DescribeAlarms'],
         resources: ['*'],
       }),
     );

--- a/cdk/lib/realarm-producer-subconstruct.ts
+++ b/cdk/lib/realarm-producer-subconstruct.ts
@@ -74,12 +74,18 @@ export class ReAlarmProducer extends Construct {
       description: 'Execution role for ReAlarm Producer Lambda function',
     });
 
+    // DescribeAlarms enumerates eligibility; ListTagsForResource is the
+    // single-alarm tag lookup for the override path; tag:GetResources is the
+    // bulk Resource Groups Tagging API sweep that builds the standard-cycle
+    // exclusion/override sets. None of these read/list actions are
+    // resource-scopable in a useful way, so they stay on '*'.
     reAlarmProducerRole.addToPolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
         actions: [
           'cloudwatch:DescribeAlarms',
           'cloudwatch:ListTagsForResource',
+          'tag:GetResources',
         ],
         resources: ['*'],
       }),

--- a/handlers/package.json
+++ b/handlers/package.json
@@ -20,6 +20,7 @@
     "@aws-sdk/client-eventbridge": "^3.800.0",
     "@aws-sdk/client-opensearch": "^3.799.0",
     "@aws-sdk/client-rds": "^3.799.0",
+    "@aws-sdk/client-resource-groups-tagging-api": "^3.799.0",
     "@aws-sdk/client-route53resolver": "^3.799.0",
     "@aws-sdk/client-sfn": "^3.799.0",
     "@aws-sdk/client-sqs": "^3.799.0",

--- a/handlers/pnpm-lock.yaml
+++ b/handlers/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@aws-sdk/client-rds':
         specifier: ^3.799.0
         version: 3.934.0
+      '@aws-sdk/client-resource-groups-tagging-api':
+        specifier: ^3.799.0
+        version: 3.1066.0
       '@aws-sdk/client-route53resolver':
         specifier: ^3.799.0
         version: 3.934.0
@@ -188,6 +191,10 @@ packages:
     resolution: {integrity: sha512-DqE5fyMeVJmBrgp+1r6dHqi7/GLghinpEtbt5weYM+fgQT4zXV6ZoJV/5iI38RV2v3VGxIsxVhLS6qGLzn5uKg==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/client-resource-groups-tagging-api@3.1066.0':
+    resolution: {integrity: sha512-h+5J47aAVbQ8xytcC9Jmyp1FOyTdqat+5w+w3+sKSioP0ZO2C7nm/PJvUZhDQ8ifVpBT965pGiYapHQ2/2PvVg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-route53resolver@3.934.0':
     resolution: {integrity: sha512-lgNXFrCwXaPXmH7Sdopm1mUXAupClumksOMfVDE3XFI9qKH7gMeQ3TxO7KKSWQxVtRL2zJR7ktZg3Wf1DtwtDg==}
     engines: {node: '>=18.0.0'}
@@ -226,6 +233,10 @@ packages:
     resolution: {integrity: sha512-b6k916ZxSrBwQPzeirncTIQXGnhps0HFOUakFt0ZEzjksePYUiEoU/SQ7VeY1j9JeAdJ24ejqddCiyLt99/3lg==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/core@3.974.20':
+    resolution: {integrity: sha512-7sDi2B2N3mc3nf1nz6FyEx/FCrJ1N1QnBmraHHQNabFaeAh2IaOOLml48/rHOD1bICHgTRkbBgNTvUzEr5Z35g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.620.1':
     resolution: {integrity: sha512-ExuILJ2qLW5ZO+rgkNRj0xiAipKT16Rk77buvPP8csR7kkCflT/gXTyzRe/uzIiETTxM7tr8xuO9MP/DQXqkfg==}
     engines: {node: '>=16.0.0'}
@@ -234,6 +245,10 @@ packages:
     resolution: {integrity: sha512-bnpIGYm7Jy46dxZa1cxMQ1sF0n2iBIT+TpOPHK51sz1N2dYOicUVWUHMDgU2xIFOVcKaqV+GV4VyicMmvDBcBQ==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.46':
+    resolution: {integrity: sha512-+GPXVS2srMOlH74S+SmC1gVuP2TvUZ0siuC0onKO93q+udP+M72dmY8wJfVQ5CX9z/9X5A1HHwz5yRIGBtskvQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.622.0':
     resolution: {integrity: sha512-VUHbr24Oll1RK3WR8XLUugLpgK9ZuxEm/NVeVqyFts1Ck9gsKpRg1x4eH7L7tW3SJ4TDEQNMbD7/7J+eoL2svg==}
     engines: {node: '>=16.0.0'}
@@ -241,6 +256,10 @@ packages:
   '@aws-sdk/credential-provider-http@3.934.0':
     resolution: {integrity: sha512-WJcfFik7MPIgjE8lmuDcCqddHKRMpifzoBzTZWqUJJWYXIy0rDfNzt6pn3/TMLwVgnCGjnXlw6dChTxLzO60RQ==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.48':
+    resolution: {integrity: sha512-fA5loSdlocacRxyUXtpoHSMuk5rsIKRDzQYVMnMxjcmFeZshaJlJ8lymy/hYKji6sne/UmNGj5pxuEs6kq/Qcg==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.623.0':
     resolution: {integrity: sha512-kvXA1SwGneqGzFwRZNpESitnmaENHGFFuuTvgGwtMe7mzXWuA/LkXdbiHmdyAzOo0iByKTCD8uetuwh3CXy4Pw==}
@@ -252,6 +271,14 @@ packages:
     resolution: {integrity: sha512-3vVKGe1F2S09G9kC0ZcpWh09opyrGOgQETllqWbuxlTVd7zBgrZWloItLIvneSDP+dWvdLFUbkD7WDWNCeGiig==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.972.53':
+    resolution: {integrity: sha512-ZfdhIOR41q8TcWEnUac+gCOb+O2LBWdHLmjedXpXz4IEFW2ppNuFcm6p0sMTavpM+zD5TYfpH5Gp7guRyqSgsQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.52':
+    resolution: {integrity: sha512-9hu2oR0qH7Fst5Tzdx+UWxm+w5zCXtErTLtOOW5hwwQc170CLwOeniRxyFY6s9mHfGEfC5zFukNBdKBwJR8mhQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.623.0':
     resolution: {integrity: sha512-qDwCOkhbu5PfaQHyuQ+h57HEx3+eFhKdtIw7aISziWkGdFrMe07yIBd7TJqGe4nxXnRF1pfkg05xeOlMId997g==}
     engines: {node: '>=16.0.0'}
@@ -259,6 +286,10 @@ packages:
   '@aws-sdk/credential-provider-node@3.934.0':
     resolution: {integrity: sha512-nguy36xi8nbH346dJjCmwWtOgfS4VfL7yHP+EEGmma+yg+J7mxgs8kA1NGQdJ8B46GdjlJPpI1P9pm7Pmz7nOw==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.55':
+    resolution: {integrity: sha512-zMGLa/dhESVqmCD7mmIFFKSwSFrJGScvCXcjvBZEVOOMauFS5JRQvLTMukFpMEFWiV6dTAlsen2ATDBulLPtbg==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.620.1':
     resolution: {integrity: sha512-hWqFMidqLAkaV9G460+1at6qa9vySbjQKKc04p59OT7lZ5cO5VH5S4aI05e+m4j364MBROjjk2ugNvfNf/8ILg==}
@@ -268,6 +299,10 @@ packages:
     resolution: {integrity: sha512-PhvpAgoJ88IOuqlUws9nvHuPex2jK+WS+0s00BQcRTwqPP0jtLT7eql6UfCRduwv2sIy3m1wnWDUubvbpejp/Q==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.46':
+    resolution: {integrity: sha512-VUoNFBIjWrUN8NbFiQiuxQEgFjvziAlBRPK+ddh27aj65gk0BYu6bLZnrdrNZwpW6vAihtSUtEMQ1PUJ32QRPA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.623.0':
     resolution: {integrity: sha512-70LZhUb3l7cttEsg4A0S4Jq3qrCT/v5Jfyl8F7w1YZJt5zr3oPPcvDJxo/UYckFz4G4/5BhGa99jK8wMlNE9QA==}
     engines: {node: '>=16.0.0'}
@@ -275,6 +310,10 @@ packages:
   '@aws-sdk/credential-provider-sso@3.934.0':
     resolution: {integrity: sha512-7wO86w95V9MZSYo2dunBKruKHdAUmgg9ccOSJSYGnPip1PPBK/rgSgQ8mDlYtFAW3/82bdeM/668QcgLT4+ofA==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.972.52':
+    resolution: {integrity: sha512-nb2/n4o/HQf+FVpVbZe9vCTFngmuDoIsltMgLAtjixaKzvzhB4J8WSDFyWgnErgLHk55ctWH+I4PU+LIHhyffg==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-web-identity@3.621.0':
     resolution: {integrity: sha512-w7ASSyfNvcx7+bYGep3VBgC3K6vEdLmlpjT7nSIHxxQf+WSdvy+HynwJosrpZax0sK5q0D1Jpn/5q+r5lwwW6w==}
@@ -285,6 +324,10 @@ packages:
   '@aws-sdk/credential-provider-web-identity@3.934.0':
     resolution: {integrity: sha512-hb+lvFxiAPcAvUorB0hrUd1kDjDRXhZgCi5426I8KUpGzZ+ALh8/ep0KXAiYe2yg9ZkyMUbMaMvYYhMFcbXRFA==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.52':
+    resolution: {integrity: sha512-lKj6aRSGbqLmpYmM24bY7a1Xmfcq2vkE3hv8CSPYfc1yCu0BPu/XEJ1L4Fm61MsU6ULLNSG8UGsffNoFUBjESA==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-host-header@3.620.0':
     resolution: {integrity: sha512-VMtPEZwqYrII/oUkffYsNWY9PZ9xpNJpMgmyU0rlDQ25O1c0Hk3fJmZRe6pEkAJ0omD7kLrqGl1DUjQVxpd/Rg==}
@@ -338,6 +381,10 @@ packages:
     resolution: {integrity: sha512-kRO61EMrDR4UuPlKAkziG6urcYXlhrFW/Ce5PjWFdjkm0ZOge75OFV1vhf/vE4Pmoop9jaAONX4E5BaIYrIQfg==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.20':
+    resolution: {integrity: sha512-IYJuLpXp2DEILVQpQOy0PMpkftv0AHEOCn52o0atyOaumA0CdWQ3klPyXdViGYLbNpESsVFMVybvHUeZAuiGxA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/region-config-resolver@3.614.0':
     resolution: {integrity: sha512-vDCeMXvic/LU0KFIUjpC3RiSTIkkvESsEfbVHiHH0YINfl8HnEqR5rj+L8+phsCeVg2+LmYwYxd5NRz4PHxt5g==}
     engines: {node: '>=16.0.0'}
@@ -349,6 +396,14 @@ packages:
   '@aws-sdk/signature-v4-multi-region@3.934.0':
     resolution: {integrity: sha512-cLphxVoHapSdouAdLSDEwR2Bktjg5dc11EpSpaLo8jcFpAXhFaDllKBfDfws0EqGY6N2CMqEjqPqxDFzmmQOQA==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.34':
+    resolution: {integrity: sha512-mx1L5qlumSOt/nKM3BFaHE2HVkWwz0i4Bw0pyYO42FfX/FeLlo8YI6csC0gSPprEk6fTIqI+CZN9RwUwKd5krQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1066.0':
+    resolution: {integrity: sha512-UqEUJq7dqa44hneLDUcX7UJy95cg8YqEWyakRpvIPnrNS3Mq+UlQHgCDGu5pvwAPtlIW4qcYbvW6reG6++FyvA==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.614.0':
     resolution: {integrity: sha512-okItqyY6L9IHdxqs+Z116y5/nda7rHxLvROxtAJdLavWTYDydxrZstImNgGWTeVdmc0xX2gJCI77UYUTQWnhRw==}
@@ -367,6 +422,10 @@ packages:
   '@aws-sdk/types@3.930.0':
     resolution: {integrity: sha512-we/vaAgwlEFW7IeftmCLlLMw+6hFs3DzZPJw7lVHbj/5HJ0bz9gndxEsS2lQoeJ1zhiiLqAqvXxmM43s0MBg0A==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/types@3.973.12':
+    resolution: {integrity: sha512-43ajd1NF0RMgX5k0hxCNUyEdrtFUsb2aHT2QvpktSC/2Eyb2Jr/JPVqdp0XIoaHWikZJq5tNWSLO6kB5q2eMCA==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-arn-parser@3.893.0':
     resolution: {integrity: sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==}
@@ -416,8 +475,16 @@ packages:
     resolution: {integrity: sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==}
     engines: {node: '>=18.0.0'}
 
+  '@aws-sdk/xml-builder@3.972.29':
+    resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws/lambda-invoke-store@0.2.0':
     resolution: {integrity: sha512-D1jAmAZQYMoPiacfgNf7AWhg3DFN3Wq/vQv3WINt9znwjzHp2x+WzdJFxxj7xZL7V1U79As6G8f7PorMYWBKsQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@aws/lambda-invoke-store@0.2.4':
+    resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
     engines: {node: '>=18.0.0'}
 
   '@babel/helper-string-parser@7.27.1':
@@ -653,6 +720,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@nodable/entities@2.1.1':
+    resolution: {integrity: sha512-Pig3HxDIoMgjdEH8OCf/dkcTmLFjJRjWuq8jSnklu284/TKOPibSRERmOykiwmyXTtv61mP+44f3GMx0tLAyjg==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -839,12 +909,20 @@ packages:
     resolution: {integrity: sha512-6gnIz3h+PEPQGDj8MnRSjDvKBah042jEoPgjFGJ4iJLBE78L4lY/n98x14XyPF4u3lN179Ub/ZKFY5za9GeLQw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.24.6':
+    resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@3.2.8':
     resolution: {integrity: sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==}
     engines: {node: '>=16.0.0'}
 
   '@smithy/credential-provider-imds@4.2.5':
     resolution: {integrity: sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.3.8':
+    resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/eventstream-codec@4.2.5':
@@ -875,6 +953,10 @@ packages:
 
   '@smithy/fetch-http-handler@5.3.6':
     resolution: {integrity: sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.4.6':
+    resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/hash-node@3.0.11':
@@ -968,6 +1050,10 @@ packages:
     resolution: {integrity: sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.7.7':
+    resolution: {integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/property-provider@3.1.11':
     resolution: {integrity: sha512-I/+TMc4XTQ3QAjXfOcUWbSS073oOEAxgx4aZy8jHaf8JQnRkq2SZWw8+PfDtBvLUjcGMdxl+YwtzWe6i5uhL/A==}
     engines: {node: '>=16.0.0'}
@@ -1024,6 +1110,10 @@ packages:
     resolution: {integrity: sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.4.6':
+    resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/smithy-client@3.7.0':
     resolution: {integrity: sha512-9wYrjAZFlqWhgVo3C4y/9kpc68jgiSsKUnsFPzr/MSiRL93+QRDafGTfhhKAb2wsr69Ru87WTiqSfQusSmWipA==}
     engines: {node: '>=16.0.0'}
@@ -1035,6 +1125,10 @@ packages:
   '@smithy/types@3.7.2':
     resolution: {integrity: sha512-bNwBYYmN8Eh9RyjS1p2gW6MIhSO2rl7X9QeLM8iTdcGRP+eDiIWDt66c9IysCc22gefKszZv+ubV9qZc7hdESg==}
     engines: {node: '>=16.0.0'}
+
+  '@smithy/types@4.14.3':
+    resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
+    engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.9.0':
     resolution: {integrity: sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==}
@@ -1305,6 +1399,9 @@ packages:
   ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
     engines: {node: '>=10'}
+
+  anynum@1.0.0:
+    resolution: {integrity: sha512-xjR9/zBVnUOP6ztMIIgShjsxui80nQUQH+5xJnvrYLs+90bF25/KJqaAi8mk+B4RDtX1Nspi6fmp4YTEts8SfA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1594,12 +1691,19 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-xml-builder@1.2.0:
+    resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
+
   fast-xml-parser@4.4.1:
     resolution: {integrity: sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==}
     hasBin: true
 
   fast-xml-parser@5.2.5:
     resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
+    hasBin: true
+
+  fast-xml-parser@5.7.3:
+    resolution: {integrity: sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==}
     hasBin: true
 
   fastq@1.19.1:
@@ -2040,6 +2144,10 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-expression-matcher@1.5.0:
+    resolution: {integrity: sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -2305,6 +2413,9 @@ packages:
   strnum@2.1.1:
     resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
 
+  strnum@2.4.0:
+    resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2510,6 +2621,10 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  xml-naming@0.1.0:
+    resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
+    engines: {node: '>=16.0.0'}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2542,7 +2657,7 @@ snapshots:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.930.0
+      '@aws-sdk/types': 3.973.12
       '@aws-sdk/util-locate-window': 3.893.0
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
@@ -2550,7 +2665,7 @@ snapshots:
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.930.0
+      '@aws-sdk/types': 3.973.12
       tslib: 2.8.1
 
   '@aws-crypto/supports-web-crypto@5.2.0':
@@ -3021,6 +3136,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/client-resource-groups-tagging-api@3.1066.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/credential-provider-node': 3.972.55
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/client-route53resolver@3.934.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -3359,6 +3487,17 @@ snapshots:
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.974.20':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/xml-builder': 3.972.29
+      '@aws/lambda-invoke-store': 0.2.4
+      '@smithy/core': 3.24.6
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      bowser: 2.12.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.620.1':
     dependencies:
       '@aws-sdk/types': 3.609.0
@@ -3372,6 +3511,14 @@ snapshots:
       '@aws-sdk/types': 3.930.0
       '@smithy/property-provider': 4.2.5
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.46':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.622.0':
@@ -3397,6 +3544,16 @@ snapshots:
       '@smithy/smithy-client': 4.9.8
       '@smithy/types': 4.9.0
       '@smithy/util-stream': 4.5.6
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.48':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.623.0(@aws-sdk/client-sso-oidc@3.623.0(@aws-sdk/client-sts@3.623.0))(@aws-sdk/client-sts@3.623.0)':
@@ -3435,6 +3592,31 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-ini@3.972.53':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/credential-provider-env': 3.972.46
+      '@aws-sdk/credential-provider-http': 3.972.48
+      '@aws-sdk/credential-provider-login': 3.972.52
+      '@aws-sdk/credential-provider-process': 3.972.46
+      '@aws-sdk/credential-provider-sso': 3.972.52
+      '@aws-sdk/credential-provider-web-identity': 3.972.52
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-node@3.623.0(@aws-sdk/client-sso-oidc@3.623.0(@aws-sdk/client-sts@3.623.0))(@aws-sdk/client-sts@3.623.0)':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.620.1
@@ -3471,6 +3653,20 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-node@3.972.55':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.46
+      '@aws-sdk/credential-provider-http': 3.972.48
+      '@aws-sdk/credential-provider-ini': 3.972.53
+      '@aws-sdk/credential-provider-process': 3.972.46
+      '@aws-sdk/credential-provider-sso': 3.972.52
+      '@aws-sdk/credential-provider-web-identity': 3.972.52
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/credential-provider-imds': 4.3.8
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.620.1':
     dependencies:
       '@aws-sdk/types': 3.609.0
@@ -3486,6 +3682,14 @@ snapshots:
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.46':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.623.0(@aws-sdk/client-sso-oidc@3.623.0(@aws-sdk/client-sts@3.623.0))':
@@ -3514,6 +3718,16 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/credential-provider-sso@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/token-providers': 3.1066.0
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.621.0(@aws-sdk/client-sts@3.623.0)':
     dependencies:
       '@aws-sdk/client-sts': 3.623.0
@@ -3533,6 +3747,15 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/credential-provider-web-identity@3.972.52':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.620.0':
     dependencies:
@@ -3683,6 +3906,19 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
+  '@aws-sdk/nested-clients@3.997.20':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/signature-v4-multi-region': 3.996.34
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@aws-sdk/region-config-resolver@3.614.0':
     dependencies:
       '@aws-sdk/types': 3.609.0
@@ -3707,6 +3943,22 @@ snapshots:
       '@smithy/protocol-http': 5.3.5
       '@smithy/signature-v4': 5.3.5
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.34':
+    dependencies:
+      '@aws-sdk/types': 3.973.12
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1066.0':
+    dependencies:
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/nested-clients': 3.997.20
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.614.0(@aws-sdk/client-sso-oidc@3.623.0(@aws-sdk/client-sts@3.623.0))':
@@ -3738,6 +3990,11 @@ snapshots:
   '@aws-sdk/types@3.930.0':
     dependencies:
       '@smithy/types': 4.9.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.973.12':
+    dependencies:
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/util-arn-parser@3.893.0':
@@ -3805,7 +4062,15 @@ snapshots:
       fast-xml-parser: 5.2.5
       tslib: 2.8.1
 
+  '@aws-sdk/xml-builder@3.972.29':
+    dependencies:
+      '@smithy/types': 4.14.3
+      fast-xml-parser: 5.7.3
+      tslib: 2.8.1
+
   '@aws/lambda-invoke-store@0.2.0': {}
+
+  '@aws/lambda-invoke-store@0.2.4': {}
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -3967,6 +4232,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@nodable/entities@2.1.1': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -4133,6 +4400,12 @@ snapshots:
       '@smithy/uuid': 1.1.0
       tslib: 2.8.1
 
+  '@smithy/core@3.24.6':
+    dependencies:
+      '@aws-crypto/crc32': 5.2.0
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@3.2.8':
     dependencies:
       '@smithy/node-config-provider': 3.1.12
@@ -4147,6 +4420,12 @@ snapshots:
       '@smithy/property-provider': 4.2.5
       '@smithy/types': 4.9.0
       '@smithy/url-parser': 4.2.5
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.3.8':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/eventstream-codec@4.2.5':
@@ -4201,6 +4480,12 @@ snapshots:
       '@smithy/querystring-builder': 4.2.5
       '@smithy/types': 4.9.0
       '@smithy/util-base64': 4.3.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/hash-node@3.0.11':
@@ -4367,6 +4652,12 @@ snapshots:
       '@smithy/types': 4.9.0
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.7.7':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@smithy/property-provider@3.1.11':
     dependencies:
       '@smithy/types': 3.7.2
@@ -4449,6 +4740,12 @@ snapshots:
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.4.6':
+    dependencies:
+      '@smithy/core': 3.24.6
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
+
   '@smithy/smithy-client@3.7.0':
     dependencies:
       '@smithy/core': 2.5.7
@@ -4470,6 +4767,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@3.7.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.14.3':
     dependencies:
       tslib: 2.8.1
 
@@ -4851,6 +5152,8 @@ snapshots:
       color-convert: 2.0.1
 
   ansi-styles@5.2.0: {}
+
+  anynum@1.0.0: {}
 
   argparse@2.0.1: {}
 
@@ -5244,6 +5547,11 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-xml-builder@1.2.0:
+    dependencies:
+      path-expression-matcher: 1.5.0
+      xml-naming: 0.1.0
+
   fast-xml-parser@4.4.1:
     dependencies:
       strnum: 1.1.2
@@ -5251,6 +5559,13 @@ snapshots:
   fast-xml-parser@5.2.5:
     dependencies:
       strnum: 2.1.1
+
+  fast-xml-parser@5.7.3:
+    dependencies:
+      '@nodable/entities': 2.1.1
+      fast-xml-builder: 1.2.0
+      path-expression-matcher: 1.5.0
+      strnum: 2.4.0
 
   fastq@1.19.1:
     dependencies:
@@ -5708,6 +6023,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-expression-matcher@1.5.0: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -6023,6 +6340,10 @@ snapshots:
 
   strnum@2.1.1: {}
 
+  strnum@2.4.0:
+    dependencies:
+      anynum: 1.0.0
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -6259,6 +6580,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  xml-naming@0.1.0: {}
 
   yocto-queue@0.1.0: {}
 

--- a/handlers/src/realarm-consumer-handler.mts
+++ b/handlers/src/realarm-consumer-handler.mts
@@ -7,9 +7,7 @@ import {
 } from 'aws-lambda';
 import {
   CloudWatchClient,
-  ListTagsForResourceCommand,
   SetAlarmStateCommand,
-  Tag,
 } from '@aws-sdk/client-cloudwatch';
 import * as logging from '@nr1e/logging';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
@@ -37,7 +35,6 @@ const log = logging.initialize({
 });
 
 // Constants for rate limiting and retries
-const TAG_RETRY_ATTEMPTS = 3;
 const DELAY_BETWEEN_OPERATIONS = 200;
 const THROTTLING_ERROR_CODES = [
   'Throttling', // CloudWatch (Query protocol) throttle error name
@@ -58,14 +55,23 @@ function isThrottlingError(error: unknown): boolean {
     (code) => errorName === code || String(error).includes(code),
   );
 }
-const MAX_CONCURRENT_TAG_REQUESTS = 5;
-const TAG_REQUEST_DELAY = 200; // 200ms between requests
-
+/**
+ * Message produced by the ReAlarm producer. The producer resolves all
+ * tag-derived facts (bulk Resource Groups Tagging API sweep for the standard
+ * cycle, single ListTagsForResource for the override path) and embeds them in
+ * the message, so this consumer performs no tag lookups. Note: the Tagging
+ * API data the producer reads is eventually consistent and can lag tag
+ * changes by minutes.
+ */
 interface AlarmMessage {
   alarmName: string;
   alarmArn: string;
   alarmActions: string[];
   isOverride?: boolean;
+  /** True when the alarm carries autoalarm:re-alarm-enabled=false. */
+  reAlarmDisabled?: boolean;
+  /** True when the alarm carries a valid autoalarm:re-alarm-minutes tag. */
+  hasOverrideTag?: boolean;
 }
 
 interface ErrorMetrics {
@@ -107,102 +113,7 @@ function logMetricsSummary() {
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
-async function fetchTagsWithRetry(
-  alarm: AlarmMessage,
-  attempts: number = TAG_RETRY_ATTEMPTS,
-): Promise<Tag[]> {
-  for (let i = 0; i < attempts; i++) {
-    try {
-      metrics.totalCalls++;
-      const tagsResponse = await cloudwatch.send(
-        new ListTagsForResourceCommand({
-          ResourceARN: alarm.alarmArn,
-        }),
-      );
-
-      if (!tagsResponse.Tags) {
-        throw new Error('No tags returned from ListTagsForResource');
-      }
-      return tagsResponse.Tags;
-    } catch (error) {
-      if (isThrottlingError(error)) {
-        metrics.throttlingErrors++;
-      }
-
-      if (i === attempts - 1) {
-        log
-          .error()
-          .str('function', 'fetchTagsWithRetry')
-          .str('alarmName', alarm.alarmName)
-          .str('error', String(error))
-          .num('attempt', i + 1)
-          .msg('Failed to fetch tags after all retry attempts');
-        throw new Error(
-          `Failed to fetch tags for alarm ${alarm.alarmName} after ${attempts} attempts: ${error}`,
-        );
-      }
-
-      log
-        .warn()
-        .str('function', 'fetchTagsWithRetry')
-        .str('alarmName', alarm.alarmName)
-        .str('error', String(error))
-        .num('attempt', i + 1)
-        .msg('Retrying tag fetch after error');
-
-      await delay(Math.pow(2, i) * 100); // Exponential backoff
-    }
-  }
-  throw new Error('Unexpected end of fetchTagsWithRetry');
-}
-
-function chunk<T>(array: T[], size: number): T[][] {
-  return Array.from({length: Math.ceil(array.length / size)}, (_, index) =>
-    array.slice(index * size, index * size + size),
-  );
-}
-
-// Create a rate limiter utility
-async function rateLimitedTagFetch(alarms: AlarmMessage[]): Promise<{
-  tagResults: Map<string, Tag[]>;
-  failedArns: Set<string>;
-}> {
-  const tagResults = new Map<string, Tag[]>();
-  const failedArns = new Set<string>();
-
-  // Process alarms in smaller chunks
-  const chunks = chunk(alarms, MAX_CONCURRENT_TAG_REQUESTS);
-
-  for (const chunk of chunks) {
-    // Process each chunk concurrently but with controlled parallelism
-    const chunkPromises = chunk.map(async (alarm) => {
-      try {
-        const tags = await fetchTagsWithRetry(alarm);
-        tagResults.set(alarm.alarmArn, tags);
-      } catch (error) {
-        // Track the failure - without tags we cannot honor opt-outs like
-        // autoalarm:re-alarm-enabled=false, so the caller must not process
-        // this alarm with an empty tag set.
-        failedArns.add(alarm.alarmArn);
-        log
-          .error()
-          .str('function', 'rateLimitedTagFetch')
-          .str('alarmArn', alarm.alarmArn)
-          .str('error', String(error))
-          .msg('Failed to fetch tags for alarm');
-      }
-      // Add delay between requests within chunk
-      await delay(TAG_REQUEST_DELAY);
-    });
-
-    // Wait for current chunk to complete before moving to next
-    await Promise.all(chunkPromises);
-  }
-
-  return {tagResults, failedArns};
-}
-
-function validateAlarm(alarm: AlarmMessage, tags: Tag[]): boolean {
+function validateAlarm(alarm: AlarmMessage): boolean {
   // Log all actions for this alarm
   log
     .info()
@@ -232,20 +143,15 @@ function validateAlarm(alarm: AlarmMessage, tags: Tag[]): boolean {
       .msg('Autoscaling actions found - alarm will be excluded');
   }
 
-  const reAlarmDisabled = tags.some(
-    (tag) => tag.Key === 'autoalarm:re-alarm-enabled' && tag.Value === 'false',
-  );
+  // Tag-derived facts are resolved by the producer and embedded in the
+  // message - no tag lookups happen here. Normalize with Boolean() so
+  // messages produced before these fields existed (in-flight during a
+  // deploy) keep their historical standard-cycle behavior.
+  const reAlarmDisabled = Boolean(alarm.reAlarmDisabled);
 
   // Only a real positive integer counts as an override (mirrors the tag-event
-  // handler). Number('') === 0, so a bare !isNaN check would treat ''/' '/'0'
-  // as an override and exclude the alarm from BOTH re-alarm paths.
-  const reAlarmOverrideTag = tags.some((tag) => {
-    if (tag.Key !== 'autoalarm:re-alarm-minutes') {
-      return false;
-    }
-    const minutes = Number(tag.Value);
-    return Number.isInteger(minutes) && minutes > 0;
-  });
+  // handler); the producer applies that rule when it sets hasOverrideTag.
+  const reAlarmOverrideTag = Boolean(alarm.hasOverrideTag);
 
   const hasAutoScalingAction = autoscalingActions.length > 0;
 
@@ -263,7 +169,7 @@ function validateAlarm(alarm: AlarmMessage, tags: Tag[]): boolean {
       String(
         !reAlarmDisabled &&
           !hasAutoScalingAction &&
-          reAlarmOverrideTag === alarm.isOverride,
+          reAlarmOverrideTag === Boolean(alarm.isOverride),
       ),
     )
     .msg('Alarm validation result');
@@ -271,7 +177,7 @@ function validateAlarm(alarm: AlarmMessage, tags: Tag[]): boolean {
   return (
     !reAlarmDisabled &&
     !hasAutoScalingAction &&
-    reAlarmOverrideTag === alarm.isOverride
+    reAlarmOverrideTag === Boolean(alarm.isOverride)
   );
 }
 
@@ -317,13 +223,13 @@ async function resetAlarmState(
 
 let currentDelay = DELAY_BETWEEN_OPERATIONS;
 
-async function processAlarm(message: AlarmMessage, tags: Tag[]): Promise<void> {
+async function processAlarm(message: AlarmMessage): Promise<void> {
   try {
     const startTime = Date.now();
     let throttleCount = 0;
 
     try {
-      if (validateAlarm(message, tags)) {
+      if (validateAlarm(message)) {
         // Reset the throttling error count before the next API call
         const previousThrottleErrors = metrics.throttlingErrors;
         await resetAlarmState(message.alarmName, message.isOverride || false);
@@ -442,37 +348,14 @@ export const handler: SQSHandler = async (
     }
   });
 
-  // Fetch all tags upfront
-  const {tagResults: tagCache, failedArns} = await rateLimitedTagFetch(
-    parsedMessages.map(({message}) => message),
-  );
-
-  // Do not process alarms whose tag fetch failed - without tags we cannot
-  // honor opt-outs (autoalarm:re-alarm-enabled=false). Report them as batch
-  // item failures so SQS retries them.
-  const processableMessages = parsedMessages.filter(({record, message}) => {
-    if (failedArns.has(message.alarmArn)) {
-      log
-        .warn()
-        .str('function', 'handler')
-        .str('messageId', record.messageId)
-        .str('alarmName', message.alarmName)
-        .msg(
-          'Skipping alarm because tag fetch failed - reporting for SQS retry',
-        );
-      batchItemFailures.push({itemIdentifier: record.messageId});
-      batchItemBodies.push(record);
-      return false;
-    }
-    return true;
-  });
+  // All tag-derived facts arrive embedded in the message body (resolved by
+  // the producer), so every successfully parsed message is processable - no
+  // per-alarm tag fetches and no tag-fetch failure handling are needed here.
+  const processableMessages = parsedMessages;
 
   try {
-    // Process messages using cached tags
     const processingResults = await Promise.allSettled(
-      processableMessages.map(({message}) =>
-        processAlarm(message, tagCache.get(message.alarmArn) || []),
-      ),
+      processableMessages.map(({message}) => processAlarm(message)),
     );
 
     // Attribute failures by index - processingResults[i] corresponds to

--- a/handlers/src/realarm-producer-handler.mts
+++ b/handlers/src/realarm-producer-handler.mts
@@ -4,7 +4,13 @@ import {
   paginateDescribeAlarms,
   MetricAlarm,
   DescribeAlarmsCommand,
+  ListTagsForResourceCommand,
 } from '@aws-sdk/client-cloudwatch';
+import {
+  ResourceGroupsTaggingAPIClient,
+  paginateGetResources,
+  ResourceTagMapping,
+} from '@aws-sdk/client-resource-groups-tagging-api';
 import {
   SQSClient,
   SendMessageBatchCommand,
@@ -13,6 +19,13 @@ import {
 import * as logging from '@nr1e/logging';
 import * as crypto from 'crypto';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
+import {
+  buildReAlarmTagSets,
+  parseOverrideMinutes,
+  ReAlarmTagSets,
+  REALARM_DISABLED_TAG_KEY,
+  REALARM_OVERRIDE_TAG_KEY,
+} from './realarm-tag-sets.mjs';
 
 // Retry up to 5 times with linear backoff (100ms + 1s per attempt) instead of
 // hammering the API with constant-delay retries.
@@ -25,6 +38,10 @@ const cloudwatch = new CloudWatchClient({
   retryStrategy: retryStrategy,
 });
 const sqs = new SQSClient({
+  region: process.env.AWS_REGION,
+  retryStrategy: retryStrategy,
+});
+const taggingApi = new ResourceGroupsTaggingAPIClient({
   region: process.env.AWS_REGION,
   retryStrategy: retryStrategy,
 });
@@ -111,6 +128,122 @@ function chunk<T>(array: T[], size: number): T[][] {
   );
 }
 
+/**
+ * Tag-derived facts embedded in each SQS message so the consumer can validate
+ * without any per-alarm tag lookups.
+ */
+interface ReAlarmTagFacts {
+  reAlarmDisabled: boolean;
+  hasOverrideTag: boolean;
+}
+
+const TAGGING_API_PAGE_SIZE = 100;
+
+/**
+ * Bulk pre-filter: one Resource Groups Tagging API sweep per re-alarm tag key
+ * per run. GetResources only returns TAGGED resources, so this builds the
+ * EXCLUSION/OVERRIDE sets - never the eligible set. DescribeAlarms remains
+ * the eligibility enumerator; alarms with no tags stay eligible (ReAlarm is
+ * opt-out by design).
+ *
+ * NOTE on eventual consistency: Resource Groups Tagging API data can lag tag
+ * changes by several minutes. Worst case, an alarm tagged
+ * autoalarm:re-alarm-enabled=false moments before a run is re-alarmed one
+ * extra time, or a freshly untagged alarm is skipped for one cycle. The
+ * single-alarm override path below uses ListTagsForResource directly and is
+ * not affected.
+ */
+async function fetchReAlarmTagSets(): Promise<ReAlarmTagSets> {
+  const mappings: ResourceTagMapping[] = [];
+
+  // GetResources ANDs multiple TagFilters together, so sweep once per tag
+  // key to find resources carrying EITHER re-alarm tag.
+  for (const tagKey of [REALARM_DISABLED_TAG_KEY, REALARM_OVERRIDE_TAG_KEY]) {
+    try {
+      const paginator = paginateGetResources(
+        {client: taggingApi},
+        {
+          ResourceTypeFilters: ['cloudwatch:alarm'],
+          TagFilters: [{Key: tagKey}],
+          ResourcesPerPage: TAGGING_API_PAGE_SIZE,
+        },
+      );
+
+      for await (const page of paginator) {
+        metrics.totalCalls++;
+        mappings.push(...(page.ResourceTagMappingList ?? []));
+      }
+    } catch (error) {
+      metrics.totalErrors++;
+      if (isThrottlingError(error)) {
+        metrics.throttlingErrors++;
+      }
+      log
+        .error()
+        .str('function', 'fetchReAlarmTagSets')
+        .str('tagKey', tagKey)
+        .str('error', String(error))
+        .msg('Failed to fetch tagged alarms from Resource Groups Tagging API');
+      throw error;
+    }
+  }
+
+  const tagSets = buildReAlarmTagSets(mappings);
+
+  log
+    .info()
+    .str('function', 'fetchReAlarmTagSets')
+    .num('taggedResources', mappings.length)
+    .num('excludedArns', tagSets.excludedArns.size)
+    .num('overrideArns', tagSets.overrideByArn.size)
+    .msg('Built ReAlarm exclusion/override sets from Tagging API');
+
+  return tagSets;
+}
+
+/**
+ * Single-alarm tag lookup for the override path (per-alarm EventBridge
+ * schedule rules invoke the producer for ONE alarm). One ListTagsForResource
+ * call is the cheapest correct form here - the Tagging API cannot filter by
+ * resource ARN, and a direct lookup avoids its propagation lag.
+ */
+async function fetchAlarmTagFacts(
+  alarmName: string,
+  alarmArn: string,
+): Promise<ReAlarmTagFacts> {
+  try {
+    metrics.totalCalls++;
+    const response = await cloudwatch.send(
+      new ListTagsForResourceCommand({ResourceARN: alarmArn}),
+    );
+    const tags = response.Tags ?? [];
+
+    return {
+      reAlarmDisabled: tags.some(
+        (tag) => tag.Key === REALARM_DISABLED_TAG_KEY && tag.Value === 'false',
+      ),
+      hasOverrideTag: tags.some(
+        (tag) =>
+          tag.Key === REALARM_OVERRIDE_TAG_KEY &&
+          parseOverrideMinutes(tag.Value) !== null,
+      ),
+    };
+  } catch (error) {
+    metrics.totalErrors++;
+    if (isThrottlingError(error)) {
+      metrics.throttlingErrors++;
+    }
+    log
+      .error()
+      .str('function', 'fetchAlarmTagFacts')
+      .str('alarmName', alarmName)
+      .str('alarmArn', alarmArn)
+      .str('error', String(error))
+      .msg('Failed to fetch tags for override alarm');
+    throw error;
+  }
+}
+
 async function getOverriddenAlarm(alarmName: string): Promise<MetricAlarm[]> {
   try {
     // Fetch the specific alarm by name
@@ -163,6 +296,7 @@ async function sendAlarmsToSQS(
   alarms: MetricAlarm[],
   queueUrl: string,
   isOverride: boolean,
+  tagFacts: ReAlarmTagFacts,
 ): Promise<void> {
   // Filter out alarms that are already in OK state
   const alarmsToProcess = alarms.filter((alarm) => {
@@ -220,6 +354,11 @@ async function sendAlarmsToSQS(
         alarmArn: alarm.AlarmArn,
         alarmActions: alarm.AlarmActions || [],
         isOverride,
+        // Tag-derived facts resolved by the producer (bulk Tagging API sweep
+        // for the standard cycle, single ListTagsForResource for overrides)
+        // so the consumer needs no tag lookups.
+        reAlarmDisabled: tagFacts.reAlarmDisabled,
+        hasOverrideTag: tagFacts.hasOverrideTag,
       }),
       MessageGroupId: `realarm-producer-${messageHash(`${alarm.AlarmName}${alarm.AlarmArn}${alarm.AlarmActions}${isOverride}-${i}`)}`,
     }));
@@ -293,14 +432,31 @@ export const handler: Handler = async (event: any): Promise<void> => {
         eventData['reAlarmOverride-AlarmName'],
       );
       if (overrideAlarms.length > 0) {
+        // Single-alarm path: resolve tag facts with one direct lookup. The
+        // consumer enforces the same parity rule as before (a message is only
+        // valid when hasOverrideTag matches isOverride), so an alarm whose
+        // override tag was removed after its schedule rule fired is skipped.
+        const alarm = overrideAlarms[0];
+        const tagFacts = await fetchAlarmTagFacts(
+          alarm.AlarmName ?? '',
+          alarm.AlarmArn ?? '',
+        );
         await sendAlarmsToSQS(
           overrideAlarms,
           process.env.CONSUMER_QUEUE_URL,
           true,
+          tagFacts,
         );
       }
     } else {
-      // Handle standard alarms case
+      // Handle standard alarms case. Build the exclusion/override sets once
+      // per run via the Tagging API (GetResources only returns tagged
+      // resources); DescribeAlarms below remains the eligibility enumerator
+      // so untagged alarms stay eligible.
+      const tagSets = await fetchReAlarmTagSets();
+      let skippedExcluded = 0;
+      let skippedOverride = 0;
+
       const paginator = paginateDescribeAlarms(
         {client: cloudwatch, pageSize: PAGE_SIZE},
         {AlarmTypes: ['MetricAlarm']},
@@ -311,17 +467,41 @@ export const handler: Handler = async (event: any): Promise<void> => {
           continue;
         }
 
-        totalAlarms += page.MetricAlarms.length;
-        await sendAlarmsToSQS(
-          page.MetricAlarms,
-          process.env.CONSUMER_QUEUE_URL,
-          false,
-        );
+        // Pre-filter: skip alarms explicitly opted out
+        // (autoalarm:re-alarm-enabled=false) and alarms with a valid
+        // re-alarm-minutes override (those are handled by their own
+        // per-alarm schedule rules via the isOverride path).
+        const eligibleAlarms = page.MetricAlarms.filter((alarm) => {
+          const arn = alarm.AlarmArn ?? '';
+          if (tagSets.excludedArns.has(arn)) {
+            skippedExcluded++;
+            return false;
+          }
+          if (tagSets.overrideByArn.has(arn)) {
+            skippedOverride++;
+            return false;
+          }
+          return true;
+        });
+
+        totalAlarms += eligibleAlarms.length;
+        if (eligibleAlarms.length > 0) {
+          await sendAlarmsToSQS(
+            eligibleAlarms,
+            process.env.CONSUMER_QUEUE_URL,
+            false,
+            // By construction every enqueued standard-cycle alarm is neither
+            // opted out nor override-tagged.
+            {reAlarmDisabled: false, hasOverrideTag: false},
+          );
+        }
 
         log
           .info()
           .str('function', 'handler')
           .num('processedAlarms', totalAlarms)
+          .num('skippedExcluded', skippedExcluded)
+          .num('skippedOverride', skippedOverride)
           .msg('Processed page of alarms');
       }
     }

--- a/handlers/src/realarm-tag-sets.mts
+++ b/handlers/src/realarm-tag-sets.mts
@@ -1,0 +1,76 @@
+import type {ResourceTagMapping} from '@aws-sdk/client-resource-groups-tagging-api';
+
+/**
+ * Tag keys that influence ReAlarm behavior. ReAlarm operates on ALL account
+ * alarms by default with tag OPT-OUT, so these tags only ever build
+ * exclusion/override sets - never an "eligible" set. Alarms with no tags at
+ * all must remain eligible for the standard re-alarm cycle.
+ */
+export const REALARM_DISABLED_TAG_KEY = 'autoalarm:re-alarm-enabled';
+export const REALARM_OVERRIDE_TAG_KEY = 'autoalarm:re-alarm-minutes';
+
+export interface ReAlarmTagSets {
+  /**
+   * Alarm ARNs explicitly opted out of ReAlarm via
+   * autoalarm:re-alarm-enabled=false.
+   */
+  excludedArns: Set<string>;
+  /**
+   * Alarm ARNs with a valid autoalarm:re-alarm-minutes override tag, mapped
+   * to the override interval. These alarms are re-alarmed by their own
+   * per-alarm EventBridge schedule rule (the isOverride path), not by the
+   * standard cycle.
+   */
+  overrideByArn: Map<string, number>;
+}
+
+/**
+ * Parses an autoalarm:re-alarm-minutes tag value. Only a real positive
+ * integer counts as an override (mirrors the tag-event handler).
+ * Number('') === 0, so a bare !isNaN check would treat ''/' '/'0' as an
+ * override and exclude the alarm from BOTH re-alarm paths.
+ */
+export function parseOverrideMinutes(value: string | undefined): number | null {
+  const minutes = Number(value);
+  return Number.isInteger(minutes) && minutes > 0 ? minutes : null;
+}
+
+/**
+ * Builds the ReAlarm exclusion and override sets from Resource Groups
+ * Tagging API GetResources results. Duplicate mappings for the same ARN
+ * (e.g. an alarm returned by sweeps for both tag keys) are harmless because
+ * each mapping carries the resource's full tag list.
+ *
+ * Matching rules intentionally mirror the consumer's historical per-alarm
+ * validation:
+ * - excluded: a tag with Key 'autoalarm:re-alarm-enabled' and Value exactly
+ *   'false' (case-sensitive).
+ * - override: a tag with Key 'autoalarm:re-alarm-minutes' whose value is a
+ *   positive integer.
+ */
+export function buildReAlarmTagSets(
+  mappings: ResourceTagMapping[],
+): ReAlarmTagSets {
+  const excludedArns = new Set<string>();
+  const overrideByArn = new Map<string, number>();
+
+  for (const mapping of mappings) {
+    const arn = mapping.ResourceARN;
+    if (!arn) {
+      continue;
+    }
+
+    for (const tag of mapping.Tags ?? []) {
+      if (tag.Key === REALARM_DISABLED_TAG_KEY && tag.Value === 'false') {
+        excludedArns.add(arn);
+      } else if (tag.Key === REALARM_OVERRIDE_TAG_KEY) {
+        const minutes = parseOverrideMinutes(tag.Value);
+        if (minutes !== null) {
+          overrideByArn.set(arn, minutes);
+        }
+      }
+    }
+  }
+
+  return {excludedArns, overrideByArn};
+}

--- a/handlers/src/realarm-tag-sets.test.mts
+++ b/handlers/src/realarm-tag-sets.test.mts
@@ -1,0 +1,84 @@
+import {test, expect, describe} from 'vitest';
+import {
+  buildReAlarmTagSets,
+  parseOverrideMinutes,
+} from './realarm-tag-sets.mjs';
+
+const ARN_A = 'arn:aws:cloudwatch:us-west-2:123456789012:alarm:alarm-a';
+const ARN_B = 'arn:aws:cloudwatch:us-west-2:123456789012:alarm:alarm-b';
+
+describe('buildReAlarmTagSets', () => {
+  test('returns empty sets for no mappings - untagged alarms stay eligible', () => {
+    const {excludedArns, overrideByArn} = buildReAlarmTagSets([]);
+    expect(excludedArns.size).toBe(0);
+    expect(overrideByArn.size).toBe(0);
+  });
+
+  test('excludes only alarms tagged re-alarm-enabled with exact value "false"', () => {
+    const {excludedArns, overrideByArn} = buildReAlarmTagSets([
+      {
+        ResourceARN: ARN_A,
+        Tags: [{Key: 'autoalarm:re-alarm-enabled', Value: 'false'}],
+      },
+      // 'true' and other values must NOT exclude (opt-out is exact-match,
+      // mirroring the consumer's historical per-alarm validation).
+      {
+        ResourceARN: ARN_B,
+        Tags: [{Key: 'autoalarm:re-alarm-enabled', Value: 'true'}],
+      },
+    ]);
+    expect(excludedArns).toEqual(new Set([ARN_A]));
+    expect(overrideByArn.size).toBe(0);
+  });
+
+  test('maps valid positive-integer re-alarm-minutes values as overrides', () => {
+    const {excludedArns, overrideByArn} = buildReAlarmTagSets([
+      {
+        ResourceARN: ARN_A,
+        Tags: [{Key: 'autoalarm:re-alarm-minutes', Value: '30'}],
+      },
+    ]);
+    expect(overrideByArn.get(ARN_A)).toBe(30);
+    expect(excludedArns.size).toBe(0);
+  });
+
+  test('rejects invalid override values (empty, zero, negative, fractional, non-numeric)', () => {
+    for (const value of ['', ' ', '0', '-5', '2.5', 'abc']) {
+      const {overrideByArn} = buildReAlarmTagSets([
+        {
+          ResourceARN: ARN_A,
+          Tags: [{Key: 'autoalarm:re-alarm-minutes', Value: value}],
+        },
+      ]);
+      expect(overrideByArn.size, `value: '${value}'`).toBe(0);
+    }
+  });
+
+  test('handles both tags on one alarm, ignores unrelated tags, dedupes repeated mappings', () => {
+    const mapping = {
+      ResourceARN: ARN_A,
+      Tags: [
+        {Key: 'autoalarm:re-alarm-enabled', Value: 'false'},
+        {Key: 'autoalarm:re-alarm-minutes', Value: '60'},
+        {Key: 'autoalarm:cpu', Value: '80/95'},
+      ],
+    };
+    // The same alarm can be returned by the sweep for each tag key.
+    const {excludedArns, overrideByArn} = buildReAlarmTagSets([
+      mapping,
+      mapping,
+    ]);
+    expect(excludedArns).toEqual(new Set([ARN_A]));
+    expect(overrideByArn).toEqual(new Map([[ARN_A, 60]]));
+  });
+});
+
+describe('parseOverrideMinutes', () => {
+  test('parses only real positive integers', () => {
+    expect(parseOverrideMinutes('15')).toBe(15);
+    expect(parseOverrideMinutes('0')).toBeNull();
+    expect(parseOverrideMinutes('')).toBeNull();
+    expect(parseOverrideMinutes(undefined)).toBeNull();
+    expect(parseOverrideMinutes('1.5')).toBeNull();
+  });
+});


### PR DESCRIPTION
Closes #238.

## Design rationale: exclusion sets, not the eligible set

ReAlarm operates on **all** account alarms by default with tag **opt-out**, so alarms with no tags must remain eligible. `GetResources` only returns **tagged** resources, which makes it suitable for building the *exclusion/override* sets — never the eligible set. Accordingly:

- **`DescribeAlarms` pagination remains the eligibility enumerator** (state + actions) in the producer.
- The producer adds **one Resource Groups Tagging API sweep per run** (`GetResources`, `ResourceTypeFilters: ['cloudwatch:alarm']`), one paginated pass per re-alarm tag key (`autoalarm:re-alarm-enabled`, `autoalarm:re-alarm-minutes`) because multiple `TagFilters` are ANDed. From the results it builds:
  - `excludedArns` — alarms tagged `autoalarm:re-alarm-enabled=false` (exact, case-sensitive — same rule the consumer used),
  - `overrideByArn` — alarms whose `autoalarm:re-alarm-minutes` value is a real positive integer (same rule the consumer used; `''`/`'0'`/negatives/fractions are not overrides).
- The standard cycle skips excluded **and** override-tagged ARNs (override alarms are handled by their per-alarm EventBridge schedule rules via the `isOverride` path) and embeds the tag-derived facts (`reAlarmDisabled`, `hasOverrideTag`) in each SQS message.
- The **consumer performs no tag lookups**: `rateLimitedTagFetch`/`fetchTagsWithRetry`/tag cache and tag-fetch-failure batching are removed; validation reads the embedded facts plus `alarmActions` from the message.
- The **single-alarm override path** (`reAlarmOverride-AlarmName` → `getOverriddenAlarm`) keeps one direct `cloudwatch:ListTagsForResource` call — the Tagging API cannot filter by resource ARN, and the direct lookup avoids its propagation lag.

The pure set-building logic lives in `handlers/src/realarm-tag-sets.mts` with unit tests.

## Call-count math

| | Before (per standard cycle) | After |
|---|---|---|
| Tag reads | **N** `ListTagsForResource` calls (one per non-OK alarm enqueued, with retries/delays) | **~2 × ceil(taggedAlarms / 100)** `GetResources` calls (only resources carrying a re-alarm tag count) |
| Override invocation | 1 `ListTagsForResource` (was in consumer) | 1 `ListTagsForResource` (now in producer) |

For an account with thousands of alarms and a handful of opted-out ones, that's thousands of per-alarm calls replaced by a couple of bulk calls — and fewer SQS messages, since excluded/override alarms are no longer enqueued at all.

## Preserved semantics checklist

- [x] **Opt-out invariant**: untagged alarms stay eligible (Tagging API builds exclusion sets only; `DescribeAlarms` enumerates).
- [x] **`re-alarm-enabled=false` opt-out**: exact, case-sensitive `Value === 'false'` match preserved.
- [x] **Override parity**: a message is only acted on when `hasOverrideTag === isOverride`, preserving the previous `reAlarmOverrideTag === isOverride` outcomes for both the standard cycle and the per-alarm schedule (`isOverride`) flow — including skipping an override invocation whose tag was removed/invalidated.
- [x] **Override validity rule**: positive-integer-only `re-alarm-minutes` (mirrors tag-event handler; `Number('') === 0` pitfall still handled, now in `parseOverrideMinutes`).
- [x] **Autoscaling-action exclusion**: unchanged — ARN service-segment match (`autoscaling` / `application-autoscaling`) on `alarmActions` from the message.
- [x] **`SetAlarmState` reason strings**: unchanged (`Resetting state from reAlarm [override ]Lambda function`).
- [x] **Batch failure attribution by `messageId`**: parse failures and processing failures still attributed per record; only the tag-fetch-failure category disappears (no consumer tag fetches remain).
- [x] **Throttle handling**: SDK retry strategy, throttling metrics, and the consumer's adaptive delay around `SetAlarmState` all preserved; the new Tagging API client uses the same retry strategy.
- [x] **Already-OK alarms** still filtered before enqueue/processing.

## Eventual consistency note

Resource Groups Tagging API data can lag tag changes by minutes: an alarm opted out moments before a run may be re-alarmed one extra time (and vice versa). Documented in a code comment on `fetchReAlarmTagSets` and in the README's ReAlarm section. The single-alarm override path uses `ListTagsForResource` directly and is unaffected.

## IAM delta

- `cdk/lib/realarm-producer-subconstruct.ts`: **+ `tag:GetResources`** (not resource-scopable; `'*'`), keeps `cloudwatch:DescribeAlarms` and `cloudwatch:ListTagsForResource` (override path).
- `cdk/lib/realarm-consumer-subconstruct.ts`: **− `cloudwatch:ListTagsForResource`** (consumer no longer calls it; verified by grep). Scoped `cloudwatch:SetAlarmState` (alarm ARNs in account/region) unchanged.

## Verification

- `handlers`: `tsc --noEmit` clean, `eslint .` clean, `prettier --check .` clean, **vitest 27/27 passed** (21 existing + 6 new for `realarm-tag-sets`).
- `cdk`: `pnpm run build` (prettier + eslint + tsc) clean, **jest 8/8 passed** (full stack synth incl. esbuild bundling of the modified handlers). No IAM test assertions cover the ReAlarm roles, so none needed updating.
- Root `pnpm install` (frozen-lockfile postinstall for both packages) passes with the new `@aws-sdk/client-resource-groups-tagging-api` dependency.