### PR TITLE
Consolidate per-service copy-paste into shared helpers

### DIFF
--- a/handlers/src/alarm-configs/utils/alarm-tools.mts
+++ b/handlers/src/alarm-configs/utils/alarm-tools.mts
@@ -489,8 +489,16 @@ async function handleAnomalyDetectionWorkflow(
   }
 }
 
-//TODO: Confirm that we do not need to differentiate between Standard Statistics and Extended Statistics
-export async function handleAnomalyAlarms(
+/**
+ * Shared implementation behind {@link handleAnomalyAlarms} and
+ * {@link handleStaticAlarms}. Creates/updates the warning and critical alarms
+ * for a config when their thresholds are set, deletes them when not, and
+ * deletes everything for the config when no thresholds are defined at all.
+ *
+ * @returns The names of the alarms created or updated.
+ */
+async function handleAlarmsForVariant(
+  variant: 'anomaly' | 'static',
   config: MetricAlarmConfig,
   service: string,
   serviceIdentifier: string,
@@ -498,6 +506,8 @@ export async function handleAnomalyAlarms(
   updatedDefaults: MetricAlarmOptions,
   storagePath?: string,
 ): Promise<string[]> {
+  const functionName =
+    variant === 'anomaly' ? 'handleAnomalyAlarms' : 'handleStaticAlarms';
   const createdAlarms: string[] = [];
 
   // Validate if thresholds are set correctly
@@ -510,10 +520,13 @@ export async function handleAnomalyAlarms(
 
   // If no thresholds are set, log and exit early
   if (!warningThresholdSet && !criticalThresholdSet && !config.defaultCreate) {
-    const alarmPrefix = `AutoAlarm-${service}-${serviceIdentifier}-${config.metricName}-anomaly-`;
+    const alarmPrefix =
+      variant === 'anomaly'
+        ? `AutoAlarm-${service}-${serviceIdentifier}-${config.metricName}-anomaly-`
+        : `AutoAlarm-${service}-${serviceIdentifier}-${config.metricName}`;
     log
       .info()
-      .str('function', 'handleAnomalyAlarms')
+      .str('function', functionName)
       .str('Service Identifier', serviceIdentifier)
       .str('alarm prefix: ', alarmPrefix)
       .msg(
@@ -530,91 +543,89 @@ export async function handleAnomalyAlarms(
   }
 
   updatedDefaults.period = validatePeriod(updatedDefaults.period);
-  validateComparisonOperator(config, updatedDefaults, 'anomaly');
+  validateComparisonOperator(config, updatedDefaults, variant);
 
-  // Handle warning anomaly alarm
-  if (warningThresholdSet) {
-    const warningAlarmName = buildAlarmName(
-      config,
-      service,
-      serviceIdentifier,
-      AlarmClassification.Warning,
-      'anomaly',
-      storagePath,
-    );
-    log
-      .info()
-      .str('function', 'handleAnomalyAlarms')
-      .str('AlarmName', warningAlarmName)
-      .msg('Creating or updating warning anomaly alarm');
-    await handleAnomalyDetectionWorkflow(
-      warningAlarmName,
-      updatedDefaults,
-      config,
-      dimensions,
-      AlarmClassification.Warning,
-      updatedDefaults.warningThreshold as number,
-    );
-    createdAlarms.push(warningAlarmName);
-  } else {
-    const warningAlarmName = buildAlarmName(
-      config,
-      service,
-      serviceIdentifier,
-      AlarmClassification.Warning,
-      'anomaly',
-      storagePath,
-    );
-    log
-      .info()
-      .str('function', 'handleAnomalyAlarms')
-      .str('AlarmName', warningAlarmName)
-      .msg('Deleting existing warning anomaly alarm due to no threshold.');
-    await deleteAlarm(warningAlarmName);
-  }
+  const workflow =
+    variant === 'anomaly'
+      ? handleAnomalyDetectionWorkflow
+      : handleStaticThresholdWorkflow;
 
-  // Handle critical anomaly alarm
-  if (criticalThresholdSet) {
-    const criticalAlarmName = buildAlarmName(
+  const classifications: {
+    classification: AlarmClassification;
+    thresholdSet: boolean;
+    threshold: number | null;
+  }[] = [
+    {
+      classification: AlarmClassification.Warning,
+      thresholdSet: warningThresholdSet,
+      threshold: updatedDefaults.warningThreshold,
+    },
+    {
+      classification: AlarmClassification.Critical,
+      thresholdSet: criticalThresholdSet,
+      threshold: updatedDefaults.criticalThreshold,
+    },
+  ];
+
+  for (const {classification, thresholdSet, threshold} of classifications) {
+    const alarmName = buildAlarmName(
       config,
       service,
       serviceIdentifier,
-      AlarmClassification.Critical,
-      'anomaly',
+      classification,
+      variant,
       storagePath,
     );
-    log
-      .info()
-      .str('function', 'handleAnomalyAlarms')
-      .str('AlarmName', criticalAlarmName)
-      .msg('Creating or updating critical anomaly alarm');
-    await handleAnomalyDetectionWorkflow(
-      criticalAlarmName,
-      updatedDefaults,
-      config,
-      dimensions,
-      AlarmClassification.Critical,
-      updatedDefaults.criticalThreshold as number,
-    );
-    createdAlarms.push(criticalAlarmName);
-  } else {
-    const criticalAlarmName = buildAlarmName(
-      config,
-      service,
-      serviceIdentifier,
-      AlarmClassification.Critical,
-      'anomaly',
-      storagePath,
-    );
-    log
-      .info()
-      .str('function', 'handleAnomalyAlarms')
-      .str('AlarmName', criticalAlarmName)
-      .msg('Deleting existing critical anomaly alarm due to no threshold.');
-    await deleteAlarm(criticalAlarmName);
+    if (thresholdSet) {
+      log
+        .info()
+        .str('function', functionName)
+        .str('AlarmName', alarmName)
+        .msg(
+          `Creating or updating ${classification.toLowerCase()} ${variant} alarms`,
+        );
+      await workflow(
+        alarmName,
+        updatedDefaults,
+        config,
+        dimensions,
+        classification,
+        threshold as number,
+      );
+      createdAlarms.push(alarmName);
+    } else {
+      log
+        .info()
+        .str('function', functionName)
+        .str('AlarmName', alarmName)
+        .msg(
+          `Deleting existing ${classification.toLowerCase()} ${variant} alarm due to no threshold.`,
+        );
+      await deleteAlarm(alarmName);
+    }
   }
 
   return createdAlarms;
+}
+
+//TODO: Confirm that we do not need to differentiate between Standard Statistics and Extended Statistics
+export async function handleAnomalyAlarms(
+  config: MetricAlarmConfig,
+  service: string,
+  serviceIdentifier: string,
+  dimensions: {Name: string; Value: string}[],
+  updatedDefaults: MetricAlarmOptions,
+  storagePath?: string,
+): Promise<string[]> {
+  return handleAlarmsForVariant(
+    'anomaly',
+    config,
+    service,
+    serviceIdentifier,
+    dimensions,
+    updatedDefaults,
+    storagePath,
+  );
 }
 
 async function handleStaticThresholdWorkflow(
@@ -691,123 +702,15 @@ export async function handleStaticAlarms(
   updatedDefaults: MetricAlarmOptions,
   storagePath?: string,
 ): Promise<string[]> {
-  const createdAlarms: string[] = [];
-
-  // Validate if thresholds are set correctly
-  const warningThresholdSet =
-    updatedDefaults.warningThreshold !== undefined &&
-    updatedDefaults.warningThreshold !== null;
-  const criticalThresholdSet =
-    updatedDefaults.criticalThreshold !== undefined &&
-    updatedDefaults.criticalThreshold !== null;
-
-  // If no thresholds are set, log and exit early
-  if (!warningThresholdSet && !criticalThresholdSet && !config.defaultCreate) {
-    const alarmPrefix = `AutoAlarm-ALB-${serviceIdentifier}-${config.metricName}`;
-    log
-      .info()
-      .str('function', 'handleStaticAlarms')
-      .str('serviceIdentifier', serviceIdentifier)
-      .str('alarm prefix: ', `${alarmPrefix}`)
-      .msg(
-        'No thresholds defined, skipping alarm creation and deleting alarms for config if they exist.',
-      );
-    await deleteAlarmsForConfig(
-      config,
-      service,
-      serviceIdentifier,
-      dimensions,
-      updatedDefaults.statistic,
-    );
-    return createdAlarms;
-  }
-
-  updatedDefaults.period = validatePeriod(updatedDefaults.period);
-  validateComparisonOperator(config, updatedDefaults, 'static');
-
-  // Handle warning static alarm
-  if (warningThresholdSet) {
-    const warningAlarmName = buildAlarmName(
-      config,
-      service,
-      serviceIdentifier,
-      AlarmClassification.Warning,
-      'static',
-      storagePath,
-    );
-    log
-      .info()
-      .str('function', 'handleStaticAlarms')
-      .str('AlarmName', warningAlarmName)
-      .msg('Creating or updating warning static alarms');
-    await handleStaticThresholdWorkflow(
-      warningAlarmName,
-      updatedDefaults,
-      config,
-      dimensions,
-      AlarmClassification.Warning,
-      updatedDefaults.warningThreshold as number,
-    );
-    createdAlarms.push(warningAlarmName);
-  } else {
-    const warningAlarmName = buildAlarmName(
-      config,
-      service,
-      serviceIdentifier,
-      AlarmClassification.Warning,
-      'static',
-      storagePath,
-    );
-    log
-      .info()
-      .str('function', 'handleStaticAlarms')
-      .str('AlarmName', warningAlarmName)
-      .msg('Deleting existing warning static alarm due to no threshold.');
-    await deleteAlarm(warningAlarmName);
-  }
-
-  // Handle critical static alarm
-  if (criticalThresholdSet) {
-    const criticalAlarmName = buildAlarmName(
-      config,
-      service,
-      serviceIdentifier,
-      AlarmClassification.Critical,
-      'static',
-      storagePath,
-    );
-    log
-      .info()
-      .str('function', 'handleStaticAlarms')
-      .str('AlarmName', criticalAlarmName)
-      .msg('Creating or updating critical static alarms');
-    await handleStaticThresholdWorkflow(
-      criticalAlarmName,
-      updatedDefaults,
-      config,
-      dimensions,
-      AlarmClassification.Critical,
-      updatedDefaults.criticalThreshold as number,
-    );
-    createdAlarms.push(criticalAlarmName);
-  } else {
-    const criticalAlarmName = buildAlarmName(
-      config,
-      service,
-      serviceIdentifier,
-      AlarmClassification.Critical,
-      'static',
-      storagePath,
-    );
-    log
-      .info()
-      .str('function', 'handleStaticAlarms')
-      .str('AlarmName', criticalAlarmName)
-      .msg('Deleting existing critical static alarm due to no threshold.');
-    await deleteAlarm(criticalAlarmName);
-  }
-
-  return createdAlarms;
+  return handleAlarmsForVariant(
+    'static',
+    config,
+    service,
+    serviceIdentifier,
+    dimensions,
+    updatedDefaults,
+    storagePath,
+  );
 }
 
 /**

--- a/handlers/src/alarm-configs/utils/index.mts
+++ b/handlers/src/alarm-configs/utils/index.mts
@@ -19,6 +19,12 @@ export {
   getCWAlarmsForInstance,
 } from './alarm-tools.mjs';
 export {
+  manageServiceAlarms,
+  filterAlarmsToDelete,
+  fetchResourceTags,
+  findArnInEvent,
+} from './service-helpers.mjs';
+export {
   EC2getCpuQuery,
   EC2getMemoryQuery,
   EC2getStorageQuery,

--- a/handlers/src/alarm-configs/utils/service-helpers.mts
+++ b/handlers/src/alarm-configs/utils/service-helpers.mts
@@ -1,0 +1,293 @@
+/**
+ * Shared helpers for the per-service modules.
+ *
+ * These consolidate the checkAndManage<Service>StatusAlarms,
+ * fetch<Service>Tags, and findArn-in-stringified-event logic that used to be
+ * copy-pasted across the service modules. EC2 keeps its bespoke alarm
+ * management (storage-path/platform-specific alarms and Prometheus rules) and
+ * is intentionally not routed through {@link manageServiceAlarms}.
+ */
+import * as logging from '@nr1e/logging';
+import {MetricAlarmConfig, Tag} from '../../types/index.mjs';
+import {Dimension} from '../../types/module-types.mjs';
+import {
+  buildExpectedAlarmNames,
+  deleteExistingAlarms,
+  getCWAlarmsForInstance,
+  handleAnomalyAlarms,
+  handleStaticAlarms,
+  massDeleteAlarms,
+} from './alarm-tools.mjs';
+import {parseMetricAlarmOptions} from './alarm-config.mjs';
+
+const log = logging.getLogger('service-helpers');
+
+/**
+ * Returns the subset of a resource's existing alarms that should be deleted:
+ * alarms that exactly match one of the names AutoAlarm could have created for
+ * this resource (so we never touch alarms of another resource whose
+ * identifier shares a prefix) and that are not in the keep set.
+ *
+ * Pure function so the reconcile diffing is unit-testable without a
+ * CloudWatch client.
+ */
+export function filterAlarmsToDelete(
+  existingAlarms: string[],
+  expectedAlarmNames: Set<string>,
+  alarmsToKeep: Set<string>,
+): string[] {
+  return existingAlarms
+    .filter((alarm) => expectedAlarmNames.has(alarm))
+    .filter((alarm) => !alarmsToKeep.has(alarm));
+}
+
+export interface ManageServiceAlarmsOptions {
+  /**
+   * Service name used in alarm names and the AlarmNamePrefix fetch
+   * (e.g. 'SQS', 'ALB', 'RDSCluster').
+   */
+  service: string;
+  /**
+   * Resource identifier embedded in alarm names (queue name, ARN,
+   * instance id, ...).
+   */
+  identifier: string;
+  /** Tags currently on the resource. */
+  tags: Tag;
+  /** The service's alarm configs. */
+  configs: MetricAlarmConfig[];
+  /** CloudWatch dimensions applied to every alarm for this resource. */
+  dimensions: Dimension[];
+  /**
+   * When false, skips the autoalarm:enabled gate. For modules whose entry
+   * point performs its own enabled/disabled handling before calling this
+   * (e.g. ECS and log groups, which gate on the tag in their event parsers).
+   * Defaults to true.
+   */
+  checkEnabled?: boolean;
+}
+
+/**
+ * Generic alarm reconciliation for a tagged resource. Implements the shape
+ * every non-EC2 service module shared:
+ *
+ * 1. If alarms are not enabled (autoalarm:enabled !== 'true'), delete all of
+ *    this resource's AutoAlarm alarms and return.
+ * 2. For each config with a default-create flag or a tag override, dispatch
+ *    to the anomaly or static alarm handler and collect the created alarm
+ *    names.
+ * 3. Fetch the resource's existing AutoAlarm alarms, restrict them to the
+ *    exact expected names for this resource, and delete any that were not
+ *    just created/kept.
+ */
+export async function manageServiceAlarms(
+  options: ManageServiceAlarmsOptions,
+): Promise<void> {
+  const {service, identifier, tags, configs, dimensions} = options;
+
+  log
+    .info()
+    .str('function', 'manageServiceAlarms')
+    .str('Service', service)
+    .str('Identifier', identifier)
+    .msg('Starting alarm management process');
+
+  if (options.checkEnabled ?? true) {
+    const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
+    if (!isAlarmEnabled) {
+      log
+        .info()
+        .str('function', 'manageServiceAlarms')
+        .str('Service', service)
+        .str('Identifier', identifier)
+        .msg('Alarm creation disabled by tag settings');
+      await deleteExistingAlarms(service, identifier, configs);
+      return;
+    }
+  }
+
+  const alarmsToKeep = new Set<string>();
+
+  for (const config of configs) {
+    log
+      .info()
+      .str('function', 'manageServiceAlarms')
+      .obj('config', config)
+      .str('Service', service)
+      .str('Identifier', identifier)
+      .msg('Processing metric configuration');
+
+    const tagValue = tags[`autoalarm:${config.tagKey}`];
+    const updatedDefaults = parseMetricAlarmOptions(
+      tagValue || '',
+      config.defaults,
+    );
+
+    if (config.defaultCreate || tagValue !== undefined) {
+      const isAnomaly = config.tagKey.includes('anomaly');
+      log
+        .info()
+        .str('function', 'manageServiceAlarms')
+        .str('Service', service)
+        .str('Identifier', identifier)
+        .msg(
+          isAnomaly
+            ? 'Tag key indicates anomaly alarm. Handling anomaly alarms'
+            : 'Tag key indicates static alarm. Handling static alarms',
+        );
+      const alarmHandler = isAnomaly ? handleAnomalyAlarms : handleStaticAlarms;
+      const alarmNames = await alarmHandler(
+        config,
+        service,
+        identifier,
+        dimensions,
+        updatedDefaults,
+      );
+      alarmNames.forEach((alarmName) => alarmsToKeep.add(alarmName));
+    } else {
+      log
+        .info()
+        .str('function', 'manageServiceAlarms')
+        .str('Service', service)
+        .str('Identifier', identifier)
+        .str('tagKey', config.tagKey)
+        .msg(
+          'No default or overridden alarm values. Marking alarms for deletion.',
+        );
+    }
+  }
+
+  // Delete alarms that are not in the alarmsToKeep set. Restrict the
+  // prefix-based fetch to this resource's exact expected alarm names so we
+  // never delete alarms of another resource whose identifier shares a prefix
+  // (e.g., 'orders' vs 'orders-dlq').
+  const expectedAlarmNames = buildExpectedAlarmNames(
+    service,
+    identifier,
+    configs,
+  );
+  const existingAlarms = await getCWAlarmsForInstance(service, identifier);
+  const alarmsToDelete = filterAlarmsToDelete(
+    existingAlarms,
+    expectedAlarmNames,
+    alarmsToKeep,
+  );
+
+  log
+    .info()
+    .str('function', 'manageServiceAlarms')
+    .str('Service', service)
+    .str('Identifier', identifier)
+    .obj('alarms to delete', alarmsToDelete)
+    .msg('Deleting alarms that are no longer needed');
+  await massDeleteAlarms(alarmsToDelete);
+
+  log
+    .info()
+    .str('function', 'manageServiceAlarms')
+    .str('Service', service)
+    .str('Identifier', identifier)
+    .msg('Finished alarm management process');
+}
+
+/**
+ * Generic tag fetcher owning the shared log-and-handle-error contract of the
+ * per-service fetch<Service>Tags wrappers. The caller supplies a closure that
+ * performs the service's SDK call and extracts a Tag record from the
+ * response.
+ *
+ * @param service - Service label used in log messages (e.g. 'SQS').
+ * @param resourceId - Resource identifier/ARN, for log context only.
+ * @param fetchFn - Closure performing the SDK call and Tag extraction.
+ * @param onError - 'rethrow' (default) propagates fetch errors so a transient
+ * API error fails the record (and is retried) instead of being treated as
+ * "no tags" and deleting the alarms. 'return-empty' preserves the legacy
+ * behavior of some modules that treat fetch errors as an empty tag set.
+ */
+export async function fetchResourceTags(
+  service: string,
+  resourceId: string,
+  fetchFn: () => Promise<Tag>,
+  onError: 'rethrow' | 'return-empty' = 'rethrow',
+): Promise<Tag> {
+  try {
+    const tags = await fetchFn();
+
+    log
+      .info()
+      .str('function', 'fetchResourceTags')
+      .str('Service', service)
+      .str('ResourceId', resourceId)
+      .str('tags', JSON.stringify(tags))
+      .msg(`Fetched ${service} tags`);
+
+    return tags;
+  } catch (error) {
+    log
+      .error()
+      .str('function', 'fetchResourceTags')
+      .str('Service', service)
+      .str('ResourceId', resourceId)
+      .err(error)
+      .msg(`Error fetching ${service} tags`);
+    if (onError === 'return-empty') {
+      return {};
+    }
+    // Rethrow so a transient API error fails the record (and is retried)
+    // instead of being treated as "no tags" and deleting the alarms.
+    throw error;
+  }
+}
+
+/**
+ * Searches an event for the first occurrence of an ARN starting with the
+ * given prefix. Serializes the event to a JSON string (unless it already is
+ * one), looks for the prefix, and extracts everything up to the next
+ * quotation mark. Logs an error and returns an empty string if no matching
+ * ARN can be found.
+ *
+ * @param event - A JSON-serializable object (or pre-serialized JSON string)
+ * to search.
+ * @param arnPrefix - The ARN prefix to look for (e.g. 'arn:aws:rds').
+ * @returns The extracted ARN, or an empty string if not found.
+ */
+export function findArnInEvent(event: unknown, arnPrefix: string): string {
+  const eventString = typeof event === 'string' ? event : JSON.stringify(event);
+
+  // 1) Find where the ARN starts.
+  const startIndex = eventString.indexOf(arnPrefix);
+  if (startIndex === -1) {
+    log
+      .error()
+      .str('function', 'findArnInEvent')
+      .str('arnPrefix', arnPrefix)
+      .str('event', eventString)
+      .msg('No ARN matching prefix found in event');
+    return '';
+  }
+
+  // 2) Find the next quote after that.
+  const endIndex = eventString.indexOf('"', startIndex);
+  if (endIndex === -1) {
+    log
+      .error()
+      .str('function', 'findArnInEvent')
+      .str('arnPrefix', arnPrefix)
+      .str('event', eventString)
+      .msg('No ending quote found for ARN');
+    return '';
+  }
+
+  // 3) Extract the ARN
+  const arn = eventString.substring(startIndex, endIndex);
+
+  log
+    .info()
+    .str('function', 'findArnInEvent')
+    .str('arn', arn)
+    .str('startIndex', startIndex.toString())
+    .str('endIndex', endIndex.toString())
+    .msg('Extracted ARN from event');
+
+  return arn;
+}

--- a/handlers/src/alarm-configs/utils/service-helpers.test.mts
+++ b/handlers/src/alarm-configs/utils/service-helpers.test.mts
@@ -1,0 +1,109 @@
+import {test, expect, describe} from 'vitest';
+import {filterAlarmsToDelete, findArnInEvent} from './service-helpers.mjs';
+import {buildExpectedAlarmNames} from './alarm-tools.mjs';
+import {SQS_CONFIGS} from '../_index.mjs';
+
+// Use the following to run tests individually:
+// npx vitest run ./alarm-configs/utils/service-helpers.test.mts
+
+describe('filterAlarmsToDelete', () => {
+  test('deletes only expected alarms that are not kept', () => {
+    const existing = [
+      'AutoAlarm-SQS-orders-NumberOfMessagesSent-Warning',
+      'AutoAlarm-SQS-orders-NumberOfMessagesSent-Critical',
+      'AutoAlarm-SQS-orders-ApproximateAgeOfOldestMessage-Warning',
+    ];
+    const expected = new Set(existing);
+    const keep = new Set(['AutoAlarm-SQS-orders-NumberOfMessagesSent-Warning']);
+
+    expect(filterAlarmsToDelete(existing, expected, keep)).toEqual([
+      'AutoAlarm-SQS-orders-NumberOfMessagesSent-Critical',
+      'AutoAlarm-SQS-orders-ApproximateAgeOfOldestMessage-Warning',
+    ]);
+  });
+
+  test('never deletes alarms outside the expected names (prefix collision)', () => {
+    // 'orders' is a prefix of 'orders-dlq', so the AlarmNamePrefix fetch for
+    // 'orders' can return the dlq queue's alarms. They must never be deleted.
+    const existing = [
+      'AutoAlarm-SQS-orders-NumberOfMessagesSent-Critical',
+      'AutoAlarm-SQS-orders-dlq-NumberOfMessagesSent-Critical',
+    ];
+    const expected = new Set([
+      'AutoAlarm-SQS-orders-NumberOfMessagesSent-Critical',
+    ]);
+    const keep = new Set<string>();
+
+    expect(filterAlarmsToDelete(existing, expected, keep)).toEqual([
+      'AutoAlarm-SQS-orders-NumberOfMessagesSent-Critical',
+    ]);
+  });
+
+  test('returns an empty array when everything is kept', () => {
+    const existing = ['AutoAlarm-SQS-orders-NumberOfMessagesSent-Warning'];
+    const expected = new Set(existing);
+    const keep = new Set(existing);
+
+    expect(filterAlarmsToDelete(existing, expected, keep)).toEqual([]);
+  });
+
+  test('works against names produced by buildExpectedAlarmNames', () => {
+    const expected = buildExpectedAlarmNames('SQS', 'orders', SQS_CONFIGS);
+
+    // Every expected name follows the AutoAlarm-SQS-orders- prefix format and
+    // both classifications are present per config.
+    expect(expected.size).toBe(SQS_CONFIGS.length * 2);
+    for (const name of expected) {
+      expect(name.startsWith('AutoAlarm-SQS-orders-')).toBe(true);
+    }
+
+    // A fetched alarm belonging to another queue is filtered out even when it
+    // shares the prefix; expected alarms not kept are returned for deletion.
+    const someExpected = [...expected].slice(0, 3);
+    const existing = [
+      ...someExpected,
+      'AutoAlarm-SQS-orders-dlq-NumberOfMessagesSent-Critical',
+    ];
+    expect(
+      filterAlarmsToDelete(existing, expected, new Set([someExpected[0]])),
+    ).toEqual(someExpected.slice(1));
+  });
+});
+
+describe('findArnInEvent', () => {
+  test('extracts an ARN from a JSON-serializable event object', () => {
+    const event = {
+      detail: {
+        responseElements: {
+          dBInstanceArn: 'arn:aws:rds:us-west-2:123456789012:db:mydb',
+        },
+      },
+    };
+    expect(findArnInEvent(event, 'arn:aws:rds')).toBe(
+      'arn:aws:rds:us-west-2:123456789012:db:mydb',
+    );
+  });
+
+  test('extracts an ARN from a pre-serialized event body string', () => {
+    const body = JSON.stringify({
+      resources: ['arn:aws:logs:us-east-1:123456789012:log-group:/my/group'],
+    });
+    expect(findArnInEvent(body, 'arn:aws:logs')).toBe(
+      'arn:aws:logs:us-east-1:123456789012:log-group:/my/group',
+    );
+  });
+
+  test('returns the first match when multiple ARNs are present', () => {
+    const event = {
+      first: 'arn:aws:rds:us-west-2:123456789012:db:first-db',
+      second: 'arn:aws:rds:us-west-2:123456789012:db:second-db',
+    };
+    expect(findArnInEvent(event, 'arn:aws:rds')).toBe(
+      'arn:aws:rds:us-west-2:123456789012:db:first-db',
+    );
+  });
+
+  test('returns an empty string when no ARN with the prefix exists', () => {
+    expect(findArnInEvent({foo: 'bar'}, 'arn:aws:rds')).toBe('');
+  });
+});

--- a/handlers/src/service-modules/alb-modules.mts
+++ b/handlers/src/service-modules/alb-modules.mts
@@ -3,21 +3,12 @@ import {
   ElasticLoadBalancingV2Client,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
 import * as logging from '@nr1e/logging';
-import {
-  LoadBalancerIdentifiers,
-  Tag,
-  AlarmClassification,
-} from '../types/index.mjs';
+import {LoadBalancerIdentifiers, Tag} from '../types/index.mjs';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  getCWAlarmsForInstance,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {ALB_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -33,167 +24,41 @@ const elbClient: ElasticLoadBalancingV2Client =
 const metricConfigs = ALB_CONFIGS;
 
 export async function fetchALBTags(loadBalancerArn: string): Promise<Tag> {
-  try {
-    const command = new DescribeTagsCommand({
-      ResourceArns: [loadBalancerArn],
-    });
-    const response = await elbClient.send(command);
-    const tags: Tag = {};
-
-    response.TagDescriptions?.forEach((tagDescription) => {
-      tagDescription.Tags?.forEach((tag) => {
-        if (tag.Key && tag.Value) {
-          tags[tag.Key] = tag.Value;
-        }
-      });
-    });
-
-    log
-      .info()
-      .str('function', 'fetchALBTags')
-      .str('loadBalancerArn', loadBalancerArn)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched ALB tags');
-
-    return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchALBTags')
-      .err(error)
-      .str('loadBalancerArn', loadBalancerArn)
-      .msg('Error fetching ALB tags');
-    return {};
-  }
-}
-
-async function checkAndManageALBStatusAlarms(
-  loadBalancerName: string,
-  tags: Tag,
-) {
-  log
-    .info()
-    .str('function', 'checkAndManageALBStatusAlarms')
-    .str('LoadBalancerName', loadBalancerName)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageALBStatusAlarms')
-      .str('LoadBalancerName', loadBalancerName)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('ALB', loadBalancerName, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageALBStatusAlarms')
-      .obj('config', config)
-      .str('LoadBalancerName', loadBalancerName)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageALBStatusAlarms')
-          .str('LoadBalancerName', loadBalancerName)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'ALB',
-          loadBalancerName,
-          [{Name: 'LoadBalancer', Value: loadBalancerName}],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName: string) =>
-          alarmsToKeep.add(alarmName),
-        );
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageALBStatusAlarms')
-          .str('LoadBalancerName', loadBalancerName)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'ALB',
-          loadBalancerName,
-          [{Name: 'LoadBalancer', Value: loadBalancerName}],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName: string) =>
-          alarmsToKeep.add(alarmName),
-        );
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageALBStatusAlarms')
-        .str('LoadBalancerName', loadBalancerName)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'ALB',
-            loadBalancerName,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-
-  // Delete alarms that are not in the alarmsToKeep set
-  // Restrict the prefix-based fetch to this resource's exact expected alarm
-  // names so we never delete alarms of another resource whose identifier
-  // shares a prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
+  return fetchResourceTags(
     'ALB',
-    loadBalancerName,
-    metricConfigs,
-  );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('ALB', loadBalancerName)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm: string) => !alarmsToKeep.has(alarm),
-  );
+    loadBalancerArn,
+    async () => {
+      const command = new DescribeTagsCommand({
+        ResourceArns: [loadBalancerArn],
+      });
+      const response = await elbClient.send(command);
+      const tags: Tag = {};
 
-  log
-    .info()
-    .str('function', 'checkAndManageALBStatusAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarms that are no longer needed');
-  await massDeleteAlarms(alarmsToDelete);
+      response.TagDescriptions?.forEach((tagDescription) => {
+        tagDescription.Tags?.forEach((tag) => {
+          if (tag.Key && tag.Value) {
+            tags[tag.Key] = tag.Value;
+          }
+        });
+      });
 
-  log
-    .info()
-    .str('function', 'checkAndManageALBStatusAlarms')
-    .str('LoadBalancerName', loadBalancerName)
-    .msg('Finished alarm management process');
+      return tags;
+    },
+    'return-empty',
+  );
 }
 
 export async function manageALBAlarms(
   loadBalancerName: string,
   tags: Tag,
 ): Promise<void> {
-  await checkAndManageALBStatusAlarms(loadBalancerName, tags);
+  await manageServiceAlarms({
+    service: 'ALB',
+    identifier: loadBalancerName,
+    tags,
+    configs: metricConfigs,
+    dimensions: [{Name: 'LoadBalancer', Value: loadBalancerName}],
+  });
 }
 
 export async function manageInactiveALBAlarms(loadBalancerName: string) {

--- a/handlers/src/service-modules/cloudfront-modules.mts
+++ b/handlers/src/service-modules/cloudfront-modules.mts
@@ -3,17 +3,12 @@ import {
   ListTagsForResourceCommand,
 } from '@aws-sdk/client-cloudfront';
 import * as logging from '@nr1e/logging';
-import {Tag, AlarmClassification} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {
-  getCWAlarmsForInstance,
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {CLOUDFRONT_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -30,165 +25,43 @@ const metricConfigs = CLOUDFRONT_CONFIGS;
 export async function fetchCloudFrontTags(
   distributionArn: string,
 ): Promise<Tag> {
-  try {
-    // Use the distributionArn directly as it's already an ARN
-    const command = new ListTagsForResourceCommand({Resource: distributionArn});
-    const response = await cloudFrontClient.send(command);
+  return fetchResourceTags(
+    'CloudFront',
+    distributionArn,
+    async () => {
+      // Use the distributionArn directly as it's already an ARN
+      const command = new ListTagsForResourceCommand({
+        Resource: distributionArn,
+      });
+      const response = await cloudFrontClient.send(command);
 
-    const tags: {[key: string]: string} = {};
-    response.Tags?.Items?.forEach((tag) => {
-      if (tag.Key && tag.Value) {
-        tags[tag.Key] = tag.Value;
-      }
-    });
+      const tags: {[key: string]: string} = {};
+      response.Tags?.Items?.forEach((tag) => {
+        if (tag.Key && tag.Value) {
+          tags[tag.Key] = tag.Value;
+        }
+      });
 
-    log
-      .info()
-      .str('function', 'fetchCloudFrontTags')
-      .str('distributionArn', distributionArn)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched tags for CloudFront distribution');
-
-    return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchCloudFrontTags')
-      .err(error)
-      .str('distributionArn', distributionArn)
-      .msg('Error fetching CloudFront tags');
-
-    return {};
-  }
-}
-
-async function checkAndManageCloudFrontStatusAlarms(
-  distributionId: string,
-  tags: Tag,
-): Promise<void> {
-  log
-    .info()
-    .str('function', 'checkAndManageCloudFrontStatusAlarms')
-    .str('distributionId', distributionId)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageCloudFrontStatusAlarms')
-      .str('distributionId', distributionId)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('CF', distributionId, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageCloudFrontStatusAlarms')
-      .obj('config', config)
-      .str('distributionId', distributionId)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageCloudFrontStatusAlarms')
-          .str('distributionId', distributionId)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'CF',
-          distributionId,
-          [
-            {Name: 'DistributionId', Value: distributionId},
-            {Name: 'Region', Value: 'Global'},
-          ],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageCloudFrontStatusAlarms')
-          .str('distributionId', distributionId)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'CF',
-          distributionId,
-          [
-            {Name: 'DistributionId', Value: distributionId},
-            {Name: 'Region', Value: 'Global'},
-          ],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageCloudFrontStatusAlarms')
-        .str('distributionId', distributionId)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'CF',
-            distributionId,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-  // Delete alarms that are not in the alarmsToKeep set
-  // Restrict the prefix-based fetch to this resource's exact expected alarm
-  // names so we never delete alarms of another resource whose identifier
-  // shares a prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
-    'CF',
-    distributionId,
-    metricConfigs,
+      return tags;
+    },
+    'return-empty',
   );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('CF', distributionId)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
-
-  log
-    .info()
-    .str('function', 'checkAndManageCloudFrontStatusAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarms that are no longer needed');
-  await massDeleteAlarms(alarmsToDelete);
-
-  log
-    .info()
-    .str('function', 'checkAndManageCloudFrontStatusAlarms')
-    .str('distributionId', distributionId)
-    .msg('Finished alarm management process');
 }
 
 export async function manageCloudFrontAlarms(
   distributionId: string,
   tags: Tag,
 ): Promise<void> {
-  await checkAndManageCloudFrontStatusAlarms(distributionId, tags);
+  await manageServiceAlarms({
+    service: 'CF',
+    identifier: distributionId,
+    tags,
+    configs: metricConfigs,
+    dimensions: [
+      {Name: 'DistributionId', Value: distributionId},
+      {Name: 'Region', Value: 'Global'},
+    ],
+  });
 }
 
 export async function manageInactiveCloudFrontAlarms(

--- a/handlers/src/service-modules/ec2-modules.mts
+++ b/handlers/src/service-modules/ec2-modules.mts
@@ -14,6 +14,7 @@ import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {
   deleteAlarm,
   doesAlarmExist,
+  fetchResourceTags,
   getCWAlarmsForInstance,
   handleAnomalyAlarms,
   handleStaticAlarms,
@@ -303,7 +304,7 @@ const metricConfigs = EC2_CONFIGS;
 export async function fetchInstanceTags(
   instanceId: string,
 ): Promise<{[key: string]: string}> {
-  try {
+  return fetchResourceTags('EC2', instanceId, async () => {
     const response = await ec2Client.send(
       new DescribeTagsCommand({
         Filters: [{Name: 'resource-id', Values: [instanceId]}],
@@ -317,25 +318,8 @@ export async function fetchInstanceTags(
       }
     });
 
-    log
-      .info()
-      .str('function', 'fetchInstanceTags')
-      .str('instanceId', instanceId)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched instance tags');
-
     return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchInstanceTags')
-      .err(error)
-      .str('instanceId', instanceId)
-      .msg('Error fetching instance tags');
-    // Rethrow so a transient API error fails the record (and is retried)
-    // instead of being treated as "no tags" and deleting the alarms.
-    throw error;
-  }
+  });
 }
 
 async function handleAlarmCreation(

--- a/handlers/src/service-modules/ecs-modules.mts
+++ b/handlers/src/service-modules/ecs-modules.mts
@@ -5,12 +5,9 @@ import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {SQSRecord} from 'aws-lambda';
 import {
   deleteExistingAlarms,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  getCWAlarmsForInstance,
-  massDeleteAlarms,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  findArnInEvent,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {ECS_CONFIGS} from '../alarm-configs/_index.mjs';
 import {Dimension} from '../types/module-types.mjs';
@@ -36,14 +33,13 @@ function extractECSServiceInfo(
   eventBody: string,
   accountId: string,
 ): ECSServiceInfo | undefined {
-  const searchIndex = 0;
   const region: string = process.env.AWS_REGION!;
 
-  const startIndex = eventBody.indexOf(
+  const arn = findArnInEvent(
+    eventBody,
     `arn:aws:ecs:${region}:${accountId}:service`,
-    searchIndex,
-  );
-  if (startIndex === -1) {
+  ).trim();
+  if (!arn) {
     log
       .error()
       .str('function', 'extractECSServiceInfo')
@@ -51,16 +47,6 @@ function extractECSServiceInfo(
     return void 0;
   }
 
-  const endIndex = eventBody.indexOf('"', startIndex);
-  if (endIndex === -1) {
-    log
-      .error()
-      .str('function', 'extractECSServiceInfo')
-      .msg('No ending quote found for ECS ARN');
-    return void 0;
-  }
-
-  const arn = eventBody.substring(startIndex, endIndex).trim();
   const arnParts = arn.split('/');
 
   if (arnParts.length < 3) {
@@ -91,7 +77,7 @@ function extractECSServiceInfo(
 }
 
 export async function fetchEcsTags(ecsArn: string): Promise<Tag> {
-  try {
+  return fetchResourceTags('ECS', ecsArn, async () => {
     const command = new ListTagsForResourceCommand({resourceArn: ecsArn});
     const response = await ecsClient.send(command);
 
@@ -102,25 +88,8 @@ export async function fetchEcsTags(ecsArn: string): Promise<Tag> {
       }
     });
 
-    log
-      .debug()
-      .str('function', 'fetchEcsTags')
-      .str('ecsArn', ecsArn)
-      .num('tagCount', Object.keys(tags).length)
-      .msg('Fetched ECS tags');
-
     return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchEcsTags')
-      .str('ecsArn', ecsArn)
-      .err(error)
-      .msg('Error fetching ECS tags');
-    // Rethrow so a transient API error fails the record (and is retried)
-    // instead of being treated as "no tags" and deleting the alarms.
-    throw error;
-  }
+  });
 }
 
 async function manageEcsAlarms(
@@ -134,102 +103,17 @@ async function manageEcsAlarms(
     {Name: 'ServiceName', Value: serviceName},
   ];
 
-  log
-    .info()
-    .str('function', 'manageEcsAlarms')
-    .str('serviceArn', serviceArn)
-    .msg('Managing ECS service alarms');
-
-  const alarmsToKeep = await createOrUpdateAlarms(
-    serviceArn,
+  // The event parser performs its own enabled/disabled gating before calling
+  // this (any present autoalarm:enabled value other than 'false' proceeds),
+  // so skip the generic strict 'true' check to preserve that behavior.
+  await manageServiceAlarms({
+    service: 'ECS',
+    identifier: serviceArn,
     tags,
-    'ECS',
+    configs: metricConfigs,
     dimensions,
-  );
-
-  await deleteUnneededAlarms(serviceArn, alarmsToKeep, 'ECS');
-
-  log
-    .info()
-    .str('function', 'manageEcsAlarms')
-    .num('alarmsManaged', alarmsToKeep.size)
-    .msg('ECS service alarm management complete');
-}
-
-async function createOrUpdateAlarms(
-  resourceArn: string,
-  tags: Tag,
-  serviceType: string,
-  dimensions: Dimension[],
-): Promise<Set<string>> {
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-
-    if (!config.defaultCreate && tagValue === undefined) {
-      continue;
-    }
-
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-
-    const alarmHandler = config.tagKey.includes('anomaly')
-      ? handleAnomalyAlarms
-      : handleStaticAlarms;
-
-    const alarmNames = await alarmHandler(
-      config,
-      serviceType,
-      resourceArn,
-      dimensions,
-      updatedDefaults,
-    );
-
-    alarmNames.forEach((name) => alarmsToKeep.add(name));
-
-    log
-      .debug()
-      .str('metricType', config.tagKey)
-      .num('alarmsCreated', alarmNames.length)
-      .msg('Processed ECS metric configuration');
-  }
-
-  return alarmsToKeep;
-}
-
-async function deleteUnneededAlarms(
-  resourceArn: string,
-  alarmsToKeep: Set<string>,
-  serviceType: string,
-): Promise<void> {
-  // Restrict the prefix-based fetch to this resource's exact expected alarm
-  // names so we never delete alarms of another resource whose identifier
-  // shares a prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
-    serviceType,
-    resourceArn,
-    metricConfigs,
-  );
-  const existingAlarms = (
-    await getCWAlarmsForInstance(serviceType, resourceArn)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
-
-  if (alarmsToDelete.length === 0) {
-    return;
-  }
-
-  await massDeleteAlarms(alarmsToDelete);
-
-  log
-    .info()
-    .num('deletedCount', alarmsToDelete.length)
-    .msg('Deleted obsolete ECS service alarms');
+    checkEnabled: false,
+  });
 }
 
 /**

--- a/handlers/src/service-modules/loggroup-modules.mts
+++ b/handlers/src/service-modules/loggroup-modules.mts
@@ -7,13 +7,10 @@ import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {SQSRecord} from 'aws-lambda';
 import {Tag} from '../types/index.mjs';
 import {
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  getCWAlarmsForInstance,
-  massDeleteAlarms,
-  parseMetricAlarmOptions,
   deleteExistingAlarms,
+  fetchResourceTags,
+  findArnInEvent,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {LOGGROUP_CONFIGS} from '../alarm-configs/loggroup-configs.mjs';
 import {Dimension} from '../types/module-types.mjs';
@@ -32,34 +29,22 @@ const metricConfigs = LOGGROUP_CONFIGS;
 export async function fetchLogGroupTags(
   arn: string,
 ): Promise<Record<string, string>> {
-  log
-    .debug()
-    .str('function', 'fetchLogGroupTags')
-    .str('inputArn', arn)
-    .str('resourceArn', arn)
-    .msg('Calling ListTagsForResource');
+  return fetchResourceTags('Logs', arn, async () => {
+    const resp = await logsClient.send(
+      new ListTagsForResourceCommand({
+        resourceArn: arn,
+      }),
+    );
 
-  const resp = await logsClient.send(
-    new ListTagsForResourceCommand({
-      resourceArn: arn,
-    }),
-  );
-
-  const tags: Record<string, string> = {};
-  for (const [key, value] of Object.entries(resp.tags ?? {})) {
-    if (key.startsWith('autoalarm:')) {
-      tags[key] = value ?? '';
+    const tags: Record<string, string> = {};
+    for (const [key, value] of Object.entries(resp.tags ?? {})) {
+      if (key.startsWith('autoalarm:')) {
+        tags[key] = value ?? '';
+      }
     }
-  }
 
-  log
-    .debug()
-    .str('function', 'fetchLogGroupTags')
-    .str('inputArn', arn)
-    .obj('Filtered AutoAlarm tags', tags)
-    .msg('ListTagsForResource complete');
-
-  return tags;
+    return tags;
+  });
 }
 
 async function manageLogGroupAlarms(
@@ -67,127 +52,18 @@ async function manageLogGroupAlarms(
   logGroupName: string,
   tags: Tag,
 ): Promise<void> {
-  log
-    .info()
-    .str('function', 'manageLogGroupAlarms')
-    .str('logGroupArn', logGroupArn)
-    .str('logGroupName', logGroupName)
-    .msg('Managing log group alarms');
-
-  const alarmsToKeep = await createOrUpdateLogGroupAlarms(
-    logGroupArn,
-    logGroupName,
-    tags,
-  );
-
-  await deleteUnneededLogGroupAlarms(logGroupArn, alarmsToKeep);
-
-  log
-    .info()
-    .str('function', 'manageLogGroupAlarms')
-    .str('logGroupArn', logGroupArn)
-    .num('alarmsManaged', alarmsToKeep.size)
-    .msg('Log group alarm management complete');
-}
-
-async function createOrUpdateLogGroupAlarms(
-  logGroupArn: string,
-  logGroupName: string,
-  tags: Tag,
-): Promise<Set<string>> {
-  log
-    .debug()
-    .str('function', 'createOrUpdateLogGroupAlarms')
-    .str('logGroupName', logGroupName)
-    .msg('Creating/updating log group alarms');
-
-  const alarmsToKeep = new Set<string>();
-
   const dimensions: Dimension[] = [{Name: 'LogGroupName', Value: logGroupName}];
 
-  for (const config of metricConfigs) {
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-
-    if (!config.defaultCreate && tagValue === undefined) {
-      continue;
-    }
-
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-
-    const isAnomaly = config.tagKey.includes('anomaly') || config.anomaly;
-
-    log
-      .info()
-      .str('function', 'createOrUpdateLogGroupAlarms')
-      .str('logGroupName', logGroupName)
-      .bool('isAnomaly', isAnomaly)
-      .msg('Determined alarm type based on tag key and configuration');
-
-    const alarmHandler = isAnomaly ? handleAnomalyAlarms : handleStaticAlarms;
-
-    log
-      .info()
-      .str('function', 'createOrUpdateLogGroupAlarms')
-      .str('logGroupName', logGroupName)
-      .str('metricType', config.tagKey)
-      .msg('Starting alarm handler');
-
-    const alarmNames = await alarmHandler(
-      config,
-      'Logs',
-      logGroupArn,
-      dimensions,
-      updatedDefaults,
-    );
-
-    alarmNames.forEach((name) => alarmsToKeep.add(name));
-
-    log
-      .debug()
-      .str('function', 'createOrUpdateLogGroupAlarms')
-      .str('logGroupName', logGroupName)
-      .str('metricType', config.tagKey)
-      .num('alarmsCreated', alarmNames.length)
-      .msg('Processed log group metric configuration');
-  }
-
-  return alarmsToKeep;
-}
-
-async function deleteUnneededLogGroupAlarms(
-  logGroupArn: string,
-  alarmsToKeep: Set<string>,
-): Promise<void> {
-  // Restrict the prefix-based fetch to this log group's exact expected alarm
-  // names so we never delete alarms of another log group whose ARN shares a
-  // prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
-    'Logs',
-    logGroupArn,
-    metricConfigs,
-  );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('Logs', logGroupArn)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
-
-  if (alarmsToDelete.length === 0) {
-    return;
-  }
-
-  await massDeleteAlarms(alarmsToDelete);
-
-  log
-    .info()
-    .str('function', 'deleteUnneededLogGroupAlarms')
-    .str('logGroupArn', logGroupArn)
-    .num('deletedCount', alarmsToDelete.length)
-    .msg('Deleted obsolete log group alarms');
+  // The event parser performs its own autoalarm:enabled gating before calling
+  // this, so skip the generic enabled check.
+  await manageServiceAlarms({
+    service: 'Logs',
+    identifier: logGroupArn,
+    tags,
+    configs: metricConfigs,
+    dimensions,
+    checkEnabled: false,
+  });
 }
 
 /**
@@ -202,9 +78,9 @@ interface ServiceInfo {
 function extractLogGroupIdentifiers(
   eventBody: string,
 ): ServiceInfo | undefined {
-  // 1) Find where the ARN starts.
-  const startIndex = eventBody.indexOf('arn:aws:logs');
-  if (startIndex === -1) {
+  // Extract the log group ARN from the raw event body.
+  const arn = findArnInEvent(eventBody, 'arn:aws:logs').trim();
+  if (!arn) {
     log
       .error()
       .str('function', 'extractLogGroupIdentifiers')
@@ -213,21 +89,7 @@ function extractLogGroupIdentifiers(
     return void 0;
   }
 
-  // 2) Find the next quote after that.
-  const endIndex = eventBody.indexOf('"', startIndex);
-  if (endIndex === -1) {
-    log
-      .error()
-      .str('function', 'extractLogGroupIdentifiers')
-      .str('eventObj', eventBody)
-      .msg('No ending quote found for logGrop ARN');
-    return void 0;
-  }
-
-  // 3) Extract the ARN
-  const arn = eventBody.substring(startIndex, endIndex).trim();
-
-  // 4) Extract LogGroup name from ARN
+  // Extract LogGroup name from ARN
   const arnParts = arn.split('log-group:');
   if (arnParts.length < 2) {
     log

--- a/handlers/src/service-modules/opensearch-modules.mts
+++ b/handlers/src/service-modules/opensearch-modules.mts
@@ -1,16 +1,11 @@
 import {OpenSearchClient, ListTagsCommand} from '@aws-sdk/client-opensearch';
 import * as logging from '@nr1e/logging';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
-import {AlarmClassification, Tag} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {
-  getCWAlarmsForInstance,
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {OPENSEARCH_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -25,163 +20,26 @@ const openSearchClient: OpenSearchClient = new OpenSearchClient({
 const metricConfigs = OPENSEARCH_CONFIGS;
 
 export async function fetchOpenSearchTags(domainArn: string): Promise<Tag> {
-  try {
-    const command = new ListTagsCommand({
-      ARN: domainArn,
-    });
-    const response = await openSearchClient.send(command);
-    const tags: Tag = {};
+  return fetchResourceTags(
+    'OpenSearch',
+    domainArn,
+    async () => {
+      const command = new ListTagsCommand({
+        ARN: domainArn,
+      });
+      const response = await openSearchClient.send(command);
+      const tags: Tag = {};
 
-    response.TagList?.forEach((tag) => {
-      if (tag.Key && tag.Value) {
-        tags[tag.Key] = tag.Value;
-      }
-    });
+      response.TagList?.forEach((tag) => {
+        if (tag.Key && tag.Value) {
+          tags[tag.Key] = tag.Value;
+        }
+      });
 
-    log
-      .info()
-      .str('function', 'fetchOpenSearchTags')
-      .str('domainArn', domainArn)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched OpenSearch tags');
-
-    return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchOpenSearchTags')
-      .err(error)
-      .str('domainArn', domainArn)
-      .msg('Error fetching OpenSearch tags');
-    return {};
-  }
-}
-
-async function checkAndManageOpenSearchStatusAlarms(
-  domainName: string,
-  accountID: string,
-  tags: Tag,
-) {
-  log
-    .info()
-    .str('function', 'checkAndManageOSStatusAlarms')
-    .str('DomainName', domainName)
-    .str('ClientId', accountID)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageOSStatusAlarms')
-      .str('DomainName', domainName)
-      .str('ClientId', accountID)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('OS', domainName, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageOSStatusAlarms')
-      .obj('config', config)
-      .str('DomainName', domainName)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageOSStatusAlarms')
-          .str('DomainName', domainName)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'OS',
-          domainName,
-          [
-            {Name: 'DomainName', Value: domainName},
-            {Name: 'ClientId', Value: accountID},
-          ],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageOSStatusAlarms')
-          .str('DomainName', domainName)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'OS',
-          domainName,
-          [
-            {Name: 'DomainName', Value: domainName},
-            {Name: 'ClientId', Value: accountID},
-          ],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageOSStatusAlarms')
-        .str('DomainName', domainName)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'OS',
-            domainName,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-
-  // Delete alarms that are not in the alarmsToKeep set
-  // Restrict the prefix-based fetch to this resource's exact expected alarm
-  // names so we never delete alarms of another resource whose identifier
-  // shares a prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
-    'OS',
-    domainName,
-    metricConfigs,
+      return tags;
+    },
+    'return-empty',
   );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('OS', domainName)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
-
-  log
-    .info()
-    .str('function', 'checkAndManageOSStatusAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarm that is no longer needed');
-  await massDeleteAlarms(alarmsToDelete);
-
-  log
-    .info()
-    .str('function', 'checkAndManageOSStatusAlarms')
-    .str('DomainName', domainName)
-    .msg('Finished alarm management process');
 }
 
 export async function manageOpenSearchAlarms(
@@ -189,7 +47,16 @@ export async function manageOpenSearchAlarms(
   accountID: string,
   tags: Tag,
 ): Promise<void> {
-  await checkAndManageOpenSearchStatusAlarms(domainName, accountID, tags);
+  await manageServiceAlarms({
+    service: 'OS',
+    identifier: domainName,
+    tags,
+    configs: metricConfigs,
+    dimensions: [
+      {Name: 'DomainName', Value: domainName},
+      {Name: 'ClientId', Value: accountID},
+    ],
+  });
 }
 
 export async function manageInactiveOpenSearchAlarms(domainName: string) {

--- a/handlers/src/service-modules/rds-cluster-modules.mts
+++ b/handlers/src/service-modules/rds-cluster-modules.mts
@@ -1,16 +1,12 @@
 import {RDSClient, DescribeDBClustersCommand} from '@aws-sdk/client-rds';
 import * as logging from '@nr1e/logging';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
-import {AlarmClassification, Tag} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {
-  getCWAlarmsForInstance,
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  findArnInEvent,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {RDS_CLUSTER_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -27,7 +23,7 @@ const metricConfigs = RDS_CLUSTER_CONFIGS;
 export async function fetchRDSClusterTags(
   dbClusterId: string,
 ): Promise<{[key: string]: string}> {
-  try {
+  return fetchResourceTags('RDSCluster', dbClusterId, async () => {
     const command = new DescribeDBClustersCommand({
       DBClusterIdentifier: dbClusterId,
     });
@@ -40,172 +36,26 @@ export async function fetchRDSClusterTags(
       }
     });
 
-    log
-      .info()
-      .str('function', 'fetchRDSClusterTags')
-      .str('dbClusterId', dbClusterId)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched database cluster tags');
-
     return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchRDSClusterTags')
-      .err(error)
-      .str('dbClusterId', dbClusterId)
-      .msg('Error fetching database cluster tags');
-    // Rethrow so a transient API error fails the record (and is retried)
-    // instead of being treated as "no tags" and deleting the alarms.
-    throw error;
-  }
+  });
 }
 
 async function checkAndManageRDSClusterStatusAlarms(
   dbClusterId: string,
   tags: Tag,
 ): Promise<void> {
-  log
-    .info()
-    .str('function', 'checkAndManageRDSClusterStatusAlarms')
-    .str('dbClusterId', dbClusterId)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageRDSClusterStatusAlarms')
-      .str('dbClusterId', dbClusterId)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('RDSCluster', dbClusterId, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageRDSClusterStatusAlarms')
-      .obj('config', config)
-      .str('dbClusterId', dbClusterId)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageRDSClusterStatusAlarms')
-          .str('dbClusterId', dbClusterId)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'RDSCluster',
-          dbClusterId,
-          [{Name: 'DBClusterIdentifier', Value: dbClusterId}],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageRDSClusterStatusAlarms')
-          .str('dbClusterId', dbClusterId)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'RDSCluster',
-          dbClusterId,
-          [{Name: 'DBClusterIdentifier', Value: dbClusterId}],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageRDSClusterStatusAlarms')
-        .str('dbClusterId', dbClusterId)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'RDSCluster',
-            dbClusterId,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-  // Delete alarms that are not in the alarmsToKeep set. Cluster alarms are
-  // created under the 'RDSCluster' service name, so fetch with that prefix and
-  // restrict deletion to this cluster's exact expected alarm names. Fetching
-  // with 'RDS' previously matched member DB instance alarms (the cluster id is
-  // a prefix of default instance ids like 'mydb-instance-1') and deleted them.
-  const expectedAlarmNames = buildExpectedAlarmNames(
-    'RDSCluster',
-    dbClusterId,
-    metricConfigs,
-  );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('RDSCluster', dbClusterId)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-
-  // Log the full structure of retrieved alarms for debugging
-  log
-    .info()
-    .str('function', 'checkAndManageRDSClusterStatusAlarms')
-    .obj('raw existing alarms', existingAlarms)
-    .msg('Fetched existing alarms before filtering');
-
-  // Log the expected pattern. buildAlarmName upper-cases the service name, so
-  // cluster alarms are prefixed 'AutoAlarm-RDSCLUSTER-'.
-  const expectedPattern = `AutoAlarm-RDSCLUSTER-${dbClusterId}`;
-  log
-    .info()
-    .str('function', 'checkAndManageRDSClusterStatusAlarms')
-    .str('expected alarm pattern', expectedPattern)
-    .msg('Verifying alarms against expected naming pattern');
-
-  // Check and log if alarms match expected pattern
-  existingAlarms.forEach((alarm) => {
-    const matchesPattern = alarm.includes(expectedPattern);
-    log
-      .info()
-      .str('function', 'checkAndManageRDSClusterStatusAlarms')
-      .str('alarm name', alarm)
-      .bool('matches expected pattern', matchesPattern)
-      .msg('Evaluating alarm name match');
+  // Cluster alarms are created under the 'RDSCluster' service name, so fetch
+  // with that prefix and restrict deletion to this cluster's exact expected
+  // alarm names. Fetching with 'RDS' previously matched member DB instance
+  // alarms (the cluster id is a prefix of default instance ids like
+  // 'mydb-instance-1') and deleted them.
+  await manageServiceAlarms({
+    service: 'RDSCluster',
+    identifier: dbClusterId,
+    tags,
+    configs: metricConfigs,
+    dimensions: [{Name: 'DBClusterIdentifier', Value: dbClusterId}],
   });
-
-  // Filter alarms that need deletion
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
-
-  log
-    .info()
-    .str('function', 'checkAndManageRDSClusterStatusAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarms that are no longer needed');
-
-  await massDeleteAlarms(alarmsToDelete);
-
-  log
-    .info()
-    .str('function', 'checkAndManageRDSClusterStatusAlarms')
-    .str('dbClusterId', dbClusterId)
-    .msg('Finished alarm management process');
 }
 
 export async function manageInactiveRDSClusterAlarms(
@@ -240,51 +90,11 @@ function extractRDSClusterIdFromArn(arn: string): string {
 
 /**
  * Searches the provided object for the first occurrence of an RDS ARN.
- * Serializes the object to a JSON string, looks for the substring "arn:aws:rds",
- * and then extracts everything up to the next quotation mark.
  * Logs an error and returns an empty string if no valid RDS ARN can be found.
- *
- * @param {Record<string, any>} eventObj - A JSON-serializable object to search for an RDS ARN.
- * @returns {string} The extracted RDS ARN, or an empty string if not found.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function findRDSClusterArn(eventObj: Record<string, any>): string {
-  const eventString = JSON.stringify(eventObj);
-
-  // 1) Find where the ARN starts.
-  const startIndex = eventString.indexOf('arn:aws:rds');
-  if (startIndex === -1) {
-    log
-      .error()
-      .str('function', 'findRDSArn')
-      .obj('eventObj', eventObj)
-      .msg('No RDS ARN found in event');
-    return '';
-  }
-
-  // 2) Find the next quote after that.
-  const endIndex = eventString.indexOf('"', startIndex);
-  if (endIndex === -1) {
-    log
-      .error()
-      .str('function', 'findRDSArn')
-      .obj('eventObj', eventObj)
-      .msg('No ending quote found for RDS ARN');
-    return '';
-  }
-
-  // 3) Extract the ARN
-  const arn = eventString.substring(startIndex, endIndex);
-
-  log
-    .info()
-    .str('function', 'findRDSArn')
-    .str('arn', arn)
-    .str('startIndex', startIndex.toString())
-    .str('endIndex', endIndex.toString())
-    .msg('Extracted RDS ARN');
-
-  return arn;
+  return findArnInEvent(eventObj, 'arn:aws:rds');
 }
 
 // On occasion AWS will splice the arn with the resource ID. If this happens, we need to remap the arn from the resource ID.

--- a/handlers/src/service-modules/rds-modules.mts
+++ b/handlers/src/service-modules/rds-modules.mts
@@ -1,16 +1,12 @@
 import {RDSClient, DescribeDBInstancesCommand} from '@aws-sdk/client-rds';
 import * as logging from '@nr1e/logging';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
-import {AlarmClassification, Tag} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {
-  getCWAlarmsForInstance,
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  findArnInEvent,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {RDS_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -27,7 +23,7 @@ const metricConfigs = RDS_CONFIGS;
 export async function fetchRDSTags(
   dbInstanceId: string,
 ): Promise<{[key: string]: string}> {
-  try {
+  return fetchResourceTags('RDS', dbInstanceId, async () => {
     const command = new DescribeDBInstancesCommand({
       DBInstanceIdentifier: dbInstanceId,
     });
@@ -40,170 +36,21 @@ export async function fetchRDSTags(
       }
     });
 
-    log
-      .info()
-      .str('function', 'fetchRDSTags')
-      .str('dbInstanceId', dbInstanceId)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched database tags');
-
     return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchRDSTags')
-      .err(error)
-      .str('dbInstanceId', dbInstanceId)
-      .msg('Error fetching database tags');
-    // Rethrow so a transient API error fails the record (and is retried)
-    // instead of being treated as "no tags" and deleting the alarms.
-    throw error;
-  }
+  });
 }
 
 async function checkAndManageRDSStatusAlarms(
   dbInstanceId: string,
   tags: Tag,
 ): Promise<void> {
-  log
-    .info()
-    .str('function', 'checkAndManageRDSStatusAlarms')
-    .str('dbInstanceId', dbInstanceId)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageRDSStatusAlarms')
-      .str('dbInstanceId', dbInstanceId)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('RDS', dbInstanceId, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageRDSStatusAlarms')
-      .obj('config', config)
-      .str('dbInstanceId', dbInstanceId)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageRDSStatusAlarms')
-          .str('dbInstanceId', dbInstanceId)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'RDS',
-          dbInstanceId,
-          [{Name: 'DBInstanceIdentifier', Value: dbInstanceId}],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageRDSStatusAlarms')
-          .str('dbInstanceId', dbInstanceId)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'RDS',
-          dbInstanceId,
-          [{Name: 'DBInstanceIdentifier', Value: dbInstanceId}],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageRDSStatusAlarms')
-        .str('dbInstanceId', dbInstanceId)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'RDS',
-            dbInstanceId,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-  // Delete alarms that are not in the alarmsToKeep set. Restrict the
-  // prefix-based fetch to this instance's exact expected alarm names so we
-  // never delete alarms of another resource whose identifier shares a prefix
-  // (e.g., 'mydb' vs 'mydb-replica').
-  const expectedAlarmNames = buildExpectedAlarmNames(
-    'RDS',
-    dbInstanceId,
-    metricConfigs,
-  );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('RDS', dbInstanceId)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-
-  // Log the full structure of retrieved alarms for debugging
-  log
-    .info()
-    .str('function', 'checkAndManageRDSStatusAlarms')
-    .obj('raw existing alarms', existingAlarms)
-    .msg('Fetched existing alarms before filtering');
-
-  // Log the expected pattern
-  const expectedPattern = `AutoAlarm-RDS-${dbInstanceId}`;
-  log
-    .info()
-    .str('function', 'checkAndManageRDSStatusAlarms')
-    .str('expected alarm pattern', expectedPattern)
-    .msg('Verifying alarms against expected naming pattern');
-
-  // Check and log if alarms match expected pattern
-  existingAlarms.forEach((alarm) => {
-    const matchesPattern = alarm.includes(expectedPattern);
-    log
-      .info()
-      .str('function', 'checkAndManageRDSStatusAlarms')
-      .str('alarm name', alarm)
-      .bool('matches expected pattern', matchesPattern)
-      .msg('Evaluating alarm name match');
+  await manageServiceAlarms({
+    service: 'RDS',
+    identifier: dbInstanceId,
+    tags,
+    configs: metricConfigs,
+    dimensions: [{Name: 'DBInstanceIdentifier', Value: dbInstanceId}],
   });
-
-  // Filter alarms that need deletion
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
-
-  log
-    .info()
-    .str('function', 'checkAndManageRDSStatusAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarms that are no longer needed');
-
-  await massDeleteAlarms(alarmsToDelete);
-
-  log
-    .info()
-    .str('function', 'checkAndManageRDSStatusAlarms')
-    .str('dbInstanceId', dbInstanceId)
-    .msg('Finished alarm management process');
 }
 
 export async function manageInactiveRDSAlarms(
@@ -314,51 +161,11 @@ function extractRDSInstanceIdFromArn(arn: string | null | undefined): string {
 
 /**
  * Searches the provided object for the first occurrence of an RDS ARN.
- * Serializes the object to a JSON string, looks for the substring "arn:aws:rds",
- * and then extracts everything up to the next quotation mark.
  * Logs an error and returns an empty string if no valid RDS ARN can be found.
- *
- * @param {Record<string, any>} eventObj - A JSON-serializable object to search for an RDS ARN.
- * @returns {string} The extracted RDS ARN, or an empty string if not found.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function findRDSArn(eventObj: Record<string, any>): string {
-  const eventString = JSON.stringify(eventObj);
-
-  // 1) Find where the ARN starts.
-  const startIndex = eventString.indexOf('arn:aws:rds');
-  if (startIndex === -1) {
-    log
-      .error()
-      .str('function', 'findRDSArn')
-      .obj('eventObj', eventObj)
-      .msg('No RDS ARN found in event');
-    return '';
-  }
-
-  // 2) Find the next quote after that.
-  const endIndex = eventString.indexOf('"', startIndex);
-  if (endIndex === -1) {
-    log
-      .error()
-      .str('function', 'findRDSArn')
-      .obj('eventObj', eventObj)
-      .msg('No ending quote found for RDS ARN');
-    return '';
-  }
-
-  // 3) Extract the ARN
-  const arn = eventString.substring(startIndex, endIndex);
-
-  log
-    .info()
-    .str('function', 'findRDSArn')
-    .str('arn', arn)
-    .str('startIndex', startIndex.toString())
-    .str('endIndex', endIndex.toString())
-    .msg('Extracted RDS ARN');
-
-  return arn;
+  return findArnInEvent(eventObj, 'arn:aws:rds');
 }
 
 export async function parseRDSEventAndCreateAlarms(

--- a/handlers/src/service-modules/route53-resolver-modules.mts
+++ b/handlers/src/service-modules/route53-resolver-modules.mts
@@ -3,17 +3,12 @@ import {
   Route53ResolverClient,
 } from '@aws-sdk/client-route53resolver';
 import * as logging from '@nr1e/logging';
-import {AlarmClassification, Tag} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  getCWAlarmsForInstance,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {ROUTE53_RESOLVER_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -28,160 +23,39 @@ const route53ResolverClient = new Route53ResolverClient({
 const metricConfigs = ROUTE53_RESOLVER_CONFIGS;
 
 export async function fetchR53ResolverTags(endpointId: string): Promise<Tag> {
-  try {
-    const command = new ListTagsForResourceCommand({
-      ResourceArn: endpointId,
-    });
-    const response = await route53ResolverClient.send(command);
-    const tags: Tag = {};
-
-    response.Tags?.forEach((tag) => {
-      if (tag.Key && tag.Value) {
-        tags[tag.Key] = tag.Value;
-      }
-    });
-
-    log
-      .info()
-      .str('function', 'fetchR53ResolverTags')
-      .str('resolverId', endpointId)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched tags for R53 Resolver Endpoint');
-    return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchR53ResolverTags')
-      .str('resolverId', endpointId)
-      .err(error)
-      .msg('Error fetching tags for R53 Resolver Endpoint');
-    return {};
-  }
-}
-
-async function checkAndManageR53ResolverStatusAlarms(
-  endpointId: string,
-  tags: Tag,
-) {
-  log
-    .info()
-    .str('function', 'checkAndManageR53ResolverStatusAlarms')
-    .str('EndpointId', endpointId)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageR53ResolverStatusAlarms')
-      .str('EndpointId', endpointId)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('R53R', endpointId, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageR53ResolverStatusAlarms')
-      .obj('config', config)
-      .str('EndpointId', endpointId)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageR53ResolverStatusAlarms')
-          .str('EndpointId', endpointId)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'R53R',
-          endpointId,
-          [{Name: 'EndpointId', Value: endpointId}],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageR53ResolverStatusAlarms')
-          .str('EndpointId', endpointId)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'R53R',
-          endpointId,
-          [{Name: 'EndpointId', Value: endpointId}],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageR53ResolverStatusAlarms')
-        .str('EndpointId', endpointId)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'R53R',
-            endpointId,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-
-  // Delete alarms that are not in the alarmsToKeep set
-  // Restrict the prefix-based fetch to this resource's exact expected alarm
-  // names so we never delete alarms of another resource whose identifier
-  // shares a prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
+  return fetchResourceTags(
     'R53R',
     endpointId,
-    metricConfigs,
-  );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('R53R', endpointId)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
+    async () => {
+      const command = new ListTagsForResourceCommand({
+        ResourceArn: endpointId,
+      });
+      const response = await route53ResolverClient.send(command);
+      const tags: Tag = {};
 
-  log
-    .info()
-    .str('function', 'checkAndManageR53ResolverStatusAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarms that are no longer needed');
-  await massDeleteAlarms(alarmsToDelete);
+      response.Tags?.forEach((tag) => {
+        if (tag.Key && tag.Value) {
+          tags[tag.Key] = tag.Value;
+        }
+      });
 
-  log
-    .info()
-    .str('function', 'checkAndManageR53ResolverStatusAlarms')
-    .str('EndpointId', endpointId)
-    .msg('Finished alarm management process');
+      return tags;
+    },
+    'return-empty',
+  );
 }
 
 export async function manageR53ResolverAlarms(
   endpointId: string,
   tags: Tag,
 ): Promise<void> {
-  await checkAndManageR53ResolverStatusAlarms(endpointId, tags);
+  await manageServiceAlarms({
+    service: 'R53R',
+    identifier: endpointId,
+    tags,
+    configs: metricConfigs,
+    dimensions: [{Name: 'EndpointId', Value: endpointId}],
+  });
 }
 
 export async function manageInactiveR53ResolverAlarms(endpointId: string) {

--- a/handlers/src/service-modules/sqs-modules.mts
+++ b/handlers/src/service-modules/sqs-modules.mts
@@ -1,16 +1,11 @@
 import {SQSClient, ListQueueTagsCommand} from '@aws-sdk/client-sqs';
 import * as logging from '@nr1e/logging';
-import {AlarmClassification, Tag} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  getCWAlarmsForInstance,
-  massDeleteAlarms,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {SQS_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -25,152 +20,24 @@ const sqsClient: SQSClient = new SQSClient({
 const metricConfigs = SQS_CONFIGS;
 
 export async function fetchSQSTags(queueUrl: string): Promise<Tag> {
-  try {
+  return fetchResourceTags('SQS', queueUrl, async () => {
     const command = new ListQueueTagsCommand({QueueUrl: queueUrl});
     const response = await sqsClient.send(command);
-    const tags: Tag = response.Tags || {};
-
-    log
-      .info()
-      .str('function', 'fetchSQSTags')
-      .str('queueUrl', queueUrl)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched SQS tags');
-
-    return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchSQSTags')
-      .err(error)
-      .str('queueUrl', queueUrl)
-      .msg('Error fetching SQS tags');
-    // Rethrow so a transient API error fails the record (and is retried)
-    // instead of being treated as "no tags" and deleting the alarms.
-    throw error;
-  }
-}
-
-async function checkAndManageSQSStatusAlarms(queueName: string, tags: Tag) {
-  log
-    .info()
-    .str('function', 'checkAndManageSQSStatusAlarms')
-    .str('QueueName', queueName)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageSQSStatusAlarms')
-      .str('QueueName', queueName)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('SQS', queueName, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageSQSStatusAlarms')
-      .obj('config', config)
-      .str('SQS', queueName)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageSQSStatusAlarms')
-          .str('QueueName', queueName)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'SQS',
-          queueName,
-          [{Name: 'QueueName', Value: queueName}],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageSQSStatusAlarms')
-          .str('QueueName', queueName)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'SQS',
-          queueName,
-          [{Name: 'QueueName', Value: queueName}],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageSQSStatusAlarms')
-        .str('QueueName', queueName)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'SQS',
-            queueName,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-
-  // Delete alarms that are not in the alarmsToKeep set. Restrict the
-  // prefix-based fetch to this queue's exact expected alarm names so we never
-  // delete alarms of another queue whose name shares a prefix (e.g., 'orders'
-  // vs 'orders-dlq').
-  const expectedAlarmNames = buildExpectedAlarmNames(
-    'SQS',
-    queueName,
-    metricConfigs,
-  );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('SQS', queueName)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
-
-  log
-    .info()
-    .str('function', 'checkAndManageSQSStatusAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarm that is no longer needed');
-  await massDeleteAlarms(alarmsToDelete);
-
-  log
-    .info()
-    .str('function', 'checkAndManageSQSStatusAlarms')
-    .str('QueueName', queueName)
-    .msg('Finished alarm management process');
+    return response.Tags || {};
+  });
 }
 
 export async function manageSQSAlarms(
   queueName: string,
   tags: Tag,
 ): Promise<void> {
-  await checkAndManageSQSStatusAlarms(queueName, tags);
+  await manageServiceAlarms({
+    service: 'SQS',
+    identifier: queueName,
+    tags,
+    configs: metricConfigs,
+    dimensions: [{Name: 'QueueName', Value: queueName}],
+  });
 }
 
 export async function manageInactiveSQSAlarms(queueUrl: string) {

--- a/handlers/src/service-modules/step-function-modules.mts
+++ b/handlers/src/service-modules/step-function-modules.mts
@@ -1,16 +1,11 @@
 import {SFNClient, ListTagsForResourceCommand} from '@aws-sdk/client-sfn';
 import * as logging from '@nr1e/logging';
-import {AlarmClassification, Tag} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  getCWAlarmsForInstance,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {STEP_FUNCTION_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -25,180 +20,39 @@ const sfnClient: SFNClient = new SFNClient({
 const metricConfigs = STEP_FUNCTION_CONFIGS;
 
 export async function fetchSFNTags(sfnArn: string): Promise<Tag> {
-  try {
-    const command = new ListTagsForResourceCommand({
-      resourceArn: sfnArn,
-    });
-    const response = await sfnClient.send(command);
-    const tags: Tag = {};
+  return fetchResourceTags(
+    'SFN',
+    sfnArn,
+    async () => {
+      const command = new ListTagsForResourceCommand({
+        resourceArn: sfnArn,
+      });
+      const response = await sfnClient.send(command);
+      const tags: Tag = {};
 
-    response.tags?.forEach((tag) => {
-      if (tag.key && tag.value) {
-        tags[tag.key] = tag.value;
-      }
-    });
+      response.tags?.forEach((tag) => {
+        if (tag.key && tag.value) {
+          tags[tag.key] = tag.value;
+        }
+      });
 
-    log
-      .info()
-      .str('function', 'fetchSFNTags')
-      .str('sfnArn', sfnArn)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched tags for SFN Arn');
-    return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchSFNTags')
-      .str('sfnArn', sfnArn)
-      .err(error)
-      .msg('Error fetching tags for SFN Arn');
-    return {};
-  }
+      return tags;
+    },
+    'return-empty',
+  );
 }
 
 async function checkAndManageSFNStatusAlarms(
   sfnArn: string,
   tags: Tag,
 ): Promise<void> {
-  log
-    .info()
-    .str('function', 'checkAndManageSFNStatusAlarms')
-    .str('sfnArn', sfnArn)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageSFNStatusAlarms')
-      .str('sfnArn', sfnArn)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('SFN', sfnArn, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageSFNStatusAlarms')
-      .obj('config', config)
-      .str('sfnArn', sfnArn)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageSFNStatusAlarms')
-          .str('sfnArn', sfnArn)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'SFN',
-          sfnArn,
-          [{Name: 'StateMachineArn', Value: sfnArn}],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageSFNStatusAlarms')
-          .str('sfnArn', sfnArn)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'SFN',
-          sfnArn,
-          [{Name: 'StateMachineArn', Value: sfnArn}],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageSFNStatusAlarms')
-        .str('sfnArn', sfnArn)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'SFN',
-            sfnArn,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-  // Delete alarms that are not in the alarmsToKeep set
-  // Restrict the prefix-based fetch to this resource's exact expected alarm
-  // names so we never delete alarms of another resource whose identifier
-  // shares a prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
-    'SFN',
-    sfnArn,
-    metricConfigs,
-  );
-  const existingAlarms = (await getCWAlarmsForInstance('SFN', sfnArn)).filter(
-    (alarm) => expectedAlarmNames.has(alarm),
-  );
-
-  // Log the full structure of retrieved alarms for debugging
-  log
-    .info()
-    .str('function', 'checkAndManageSFNStatusAlarms')
-    .obj('raw existing alarms', existingAlarms)
-    .msg('Fetched existing alarms before filtering');
-
-  // Log the expected pattern
-  const expectedPattern = `AutoAlarm-SFN-${sfnArn}`;
-  log
-    .info()
-    .str('function', 'checkAndManageSFNStatusAlarms')
-    .str('expected alarm pattern', expectedPattern)
-    .msg('Verifying alarms against expected naming pattern');
-
-  // Check and log if alarms match expected pattern
-  existingAlarms.forEach((alarm) => {
-    const matchesPattern = alarm.includes(expectedPattern);
-    log
-      .info()
-      .str('function', 'checkAndManageSFNStatusAlarms')
-      .str('alarm name', alarm)
-      .bool('matches expected pattern', matchesPattern)
-      .msg('Evaluating alarm name match');
+  await manageServiceAlarms({
+    service: 'SFN',
+    identifier: sfnArn,
+    tags,
+    configs: metricConfigs,
+    dimensions: [{Name: 'StateMachineArn', Value: sfnArn}],
   });
-
-  // Filter alarms that need deletion
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
-
-  log
-    .info()
-    .str('function', 'checkAndManageSFNStatusAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarms that are no longer needed');
-
-  await massDeleteAlarms(alarmsToDelete);
-
-  log
-    .info()
-    .str('function', 'checkAndManageSFNStatusAlarms')
-    .str('sfnArn', sfnArn)
-    .msg('Finished alarm management process');
 }
 
 export async function manageInactiveSFNAlarms(sfnArn: string): Promise<void> {

--- a/handlers/src/service-modules/targetgroup-modules.mts
+++ b/handlers/src/service-modules/targetgroup-modules.mts
@@ -5,17 +5,12 @@ import {
   DescribeTargetGroupsCommandOutput,
 } from '@aws-sdk/client-elastic-load-balancing-v2';
 import * as logging from '@nr1e/logging';
-import {AlarmClassification, Tag} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  getCWAlarmsForInstance,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import * as arnparser from '@aws-sdk/util-arn-parser';
 import {TARGET_GROUP_CONFIGS} from '../alarm-configs/_index.mjs';
@@ -32,38 +27,28 @@ const elbClient: ElasticLoadBalancingV2Client =
 const metricConfigs = TARGET_GROUP_CONFIGS;
 
 export async function fetchTGTags(targetGroupArn: string): Promise<Tag> {
-  try {
-    const command = new DescribeTagsCommand({
-      ResourceArns: [targetGroupArn],
-    });
-    const response = await elbClient.send(command);
-    const tags: Tag = {};
-
-    response.TagDescriptions?.forEach((tagDescription) => {
-      tagDescription.Tags?.forEach((tag) => {
-        if (tag.Key && tag.Value) {
-          tags[tag.Key] = tag.Value;
-        }
+  return fetchResourceTags(
+    'TG',
+    targetGroupArn,
+    async () => {
+      const command = new DescribeTagsCommand({
+        ResourceArns: [targetGroupArn],
       });
-    });
+      const response = await elbClient.send(command);
+      const tags: Tag = {};
 
-    log
-      .info()
-      .str('function', 'fetchTGTags')
-      .str('targetGroupArn', targetGroupArn)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched target group tags');
+      response.TagDescriptions?.forEach((tagDescription) => {
+        tagDescription.Tags?.forEach((tag) => {
+          if (tag.Key && tag.Value) {
+            tags[tag.Key] = tag.Value;
+          }
+        });
+      });
 
-    return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchTGTags')
-      .err(error)
-      .str('targetGroupArn', targetGroupArn)
-      .msg('Error fetching target group tags');
-    return {};
-  }
+      return tags;
+    },
+    'return-empty',
+  );
 }
 
 async function manageTGAlarms(
@@ -71,147 +56,32 @@ async function manageTGAlarms(
   loadBalancerName: string | null,
   tags: Tag,
 ) {
-  log
-    .info()
-    .str('function', 'checkAndManageTGStatusAlarms')
-    .str('TargetGroupName', targetGroupName)
-    .str('LoadBalancerName', loadBalancerName)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
+  // A load balancer is required for all TG metrics. Preserve the original
+  // ordering: the enabled check (which may delete alarms) runs first inside
+  // manageServiceAlarms, and the missing-LB guard only skips alarm creation
+  // when alarms are enabled.
+  if (tags['autoalarm:enabled'] === 'true' && !loadBalancerName) {
     log
-      .info()
-      .str('function', 'checkAndManageTGStatusAlarms')
+      .warn()
+      .str('function', 'manageTGAlarms')
       .str('TargetGroupName', targetGroupName)
       .str('LoadBalancerName', loadBalancerName)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('TG', targetGroupName, metricConfigs);
+      .msg(
+        'Load balancer name not found but required, skipping alarm creation',
+      );
     return;
   }
 
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    /*
-     * log warning if LB is not associated with tg and skip creating alarms as LB is required for all TG Metrics
-     */
-    if (!loadBalancerName) {
-      log
-        .warn()
-        .str('function', 'checkAndManageTGStatusAlarms')
-        .str('TargetGroupName', targetGroupName)
-        .str('LoadBalancerName', loadBalancerName)
-        .msg(
-          `Load balancer name not found but required, skipping alarm creation`,
-        );
-      return;
-    }
-    log
-      .info()
-      .str('function', 'checkAndManageTGStatusAlarms')
-      .obj('config', config)
-      .str('TargetGroupName', targetGroupName)
-      .str('LoadBalancerName', loadBalancerName)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageTGStatusAlarms')
-          .str('TargetGroupName', targetGroupName)
-          .str('LoadBalancerName', loadBalancerName)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'TG',
-          targetGroupName,
-          [
-            {Name: 'TargetGroup', Value: targetGroupName},
-            {Name: 'LoadBalancer', Value: loadBalancerName!}, // LoadBalancerName will always be provided if the function reaches this point and beyond
-          ],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageTGStatusAlarms')
-          .str('TargetGroupName', targetGroupName)
-          .str('LoadBalancerName', loadBalancerName)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'TG',
-          targetGroupName,
-          [
-            {Name: 'TargetGroup', Value: targetGroupName},
-            {Name: 'LoadBalancer', Value: loadBalancerName!},
-          ],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageTGStatusAlarms')
-        .str('TargetGroupName', targetGroupName)
-        .str('LoadBalancerName', loadBalancerName)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'TG',
-            targetGroupName,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-
-  // Delete alarms that are not in the alarmsToKeep set
-  // Restrict the prefix-based fetch to this resource's exact expected alarm
-  // names so we never delete alarms of another resource whose identifier
-  // shares a prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
-    'TG',
-    targetGroupName,
-    metricConfigs,
-  );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('TG', targetGroupName)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
-
-  log
-    .info()
-    .str('function', 'checkAndManageTGStatusAlarms')
-    .obj('existing alarms', existingAlarms)
-    .obj('alarms to keep', alarmsToKeep)
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarms that are no longer needed');
-  await massDeleteAlarms(alarmsToDelete);
-
-  log
-    .info()
-    .str('function', 'checkAndManageTGStatusAlarms')
-    .str('TargetGroupName', targetGroupName)
-    .str('LoadBalancerName', loadBalancerName)
-    .msg('Finished alarm management process');
+  await manageServiceAlarms({
+    service: 'TG',
+    identifier: targetGroupName,
+    tags,
+    configs: metricConfigs,
+    dimensions: [
+      {Name: 'TargetGroup', Value: targetGroupName},
+      {Name: 'LoadBalancer', Value: loadBalancerName ?? ''},
+    ],
+  });
 }
 
 export async function manageInactiveTGAlarms(targetGroupName: string) {

--- a/handlers/src/service-modules/transit-gateway-modules.mts
+++ b/handlers/src/service-modules/transit-gateway-modules.mts
@@ -1,16 +1,11 @@
 import {EC2Client, DescribeTagsCommand} from '@aws-sdk/client-ec2';
 import * as logging from '@nr1e/logging';
-import {AlarmClassification, Tag} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  getCWAlarmsForInstance,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {TRANSIT_GATEWAY_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -27,159 +22,40 @@ const metricConfigs = TRANSIT_GATEWAY_CONFIGS;
 export async function fetchTransitGatewayTags(
   transitGatewayId: string,
 ): Promise<{[key: string]: string}> {
-  try {
-    const response = await ec2Client.send(
-      new DescribeTagsCommand({
-        Filters: [{Name: 'resource-id', Values: [transitGatewayId]}],
-      }),
-    );
-
-    const tags: {[key: string]: string} = {};
-    response.Tags?.forEach((tag) => {
-      if (tag.Key && tag.Value) {
-        tags[tag.Key] = tag.Value;
-      }
-    });
-
-    log
-      .info()
-      .str('function', 'fetchTransitGatewayTags')
-      .str('transitGatewayId', transitGatewayId)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched tags for Transit Gateway');
-
-    return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchTransitGatewayTags')
-      .err(error)
-      .msg('Error fetching tags for Transit Gateway');
-    return {};
-  }
-}
-
-async function checkAndManageTransitGatewayStatusAlarms(
-  transitGatewayId: string,
-  tags: Tag,
-): Promise<void> {
-  log
-    .info()
-    .str('function', 'checkAndManageTransitGatewayStaticAlarms')
-    .str('transitGatewayId', transitGatewayId)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageTransitGatewayStaticAlarms')
-      .str('transitGatewayId', transitGatewayId)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('TGW', transitGatewayId, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageTransitGatewayStaticAlarms')
-      .obj('config', config)
-      .str('transitGatewayId', transitGatewayId)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageTransitGatewayStaticAlarms')
-          .str('transitGatewayId', transitGatewayId)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'TGW',
-          transitGatewayId,
-          [{Name: 'TransitGateway', Value: transitGatewayId}],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageTransitGatewayStaticAlarms')
-          .str('transitGatewayId', transitGatewayId)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'TGW',
-          transitGatewayId,
-          [{Name: 'TransitGateway', Value: transitGatewayId}],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageTransitGatewayStaticAlarms')
-        .str('transitGatewayId', transitGatewayId)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'TGW',
-            transitGatewayId,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-  // Delete alarms that are not in the alarmsToKeep set
-  // Restrict the prefix-based fetch to this resource's exact expected alarm
-  // names so we never delete alarms of another resource whose identifier
-  // shares a prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
+  return fetchResourceTags(
     'TGW',
     transitGatewayId,
-    metricConfigs,
-  );
-  const existingAlarms = (
-    await getCWAlarmsForInstance('TGW', transitGatewayId)
-  ).filter((alarm) => expectedAlarmNames.has(alarm));
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
+    async () => {
+      const response = await ec2Client.send(
+        new DescribeTagsCommand({
+          Filters: [{Name: 'resource-id', Values: [transitGatewayId]}],
+        }),
+      );
 
-  log
-    .info()
-    .str('function', 'checkAndManageTransitGatewayStaticAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarms that are no longer needed');
-  await massDeleteAlarms(alarmsToDelete);
+      const tags: {[key: string]: string} = {};
+      response.Tags?.forEach((tag) => {
+        if (tag.Key && tag.Value) {
+          tags[tag.Key] = tag.Value;
+        }
+      });
 
-  log
-    .info()
-    .str('function', 'checkAndManageTransitGatewayStaticAlarms')
-    .str('transitGatewayId', transitGatewayId)
-    .msg('Finished alarm management process');
+      return tags;
+    },
+    'return-empty',
+  );
 }
 
 export async function manageTransitGatewayAlarms(
   transitGatewayId: string,
   tags: Tag,
 ): Promise<void> {
-  await checkAndManageTransitGatewayStatusAlarms(transitGatewayId, tags);
+  await manageServiceAlarms({
+    service: 'TGW',
+    identifier: transitGatewayId,
+    tags,
+    configs: metricConfigs,
+    dimensions: [{Name: 'TransitGateway', Value: transitGatewayId}],
+  });
 }
 
 export async function manageInactiveTransitGatewayAlarms(

--- a/handlers/src/service-modules/vpn-modules.mts
+++ b/handlers/src/service-modules/vpn-modules.mts
@@ -1,16 +1,11 @@
 import {EC2Client, DescribeTagsCommand} from '@aws-sdk/client-ec2';
 import * as logging from '@nr1e/logging';
-import {AlarmClassification, Tag} from '../types/index.mjs';
+import {Tag} from '../types/index.mjs';
 import {ConfiguredRetryStrategy} from '@smithy/util-retry';
 import {
   deleteExistingAlarms,
-  buildAlarmName,
-  buildExpectedAlarmNames,
-  handleAnomalyAlarms,
-  handleStaticAlarms,
-  massDeleteAlarms,
-  getCWAlarmsForInstance,
-  parseMetricAlarmOptions,
+  fetchResourceTags,
+  manageServiceAlarms,
 } from '../alarm-configs/utils/index.mjs';
 import {VPN_CONFIGS} from '../alarm-configs/_index.mjs';
 
@@ -27,156 +22,37 @@ const metricConfigs = VPN_CONFIGS;
 export async function fetchVpnTags(
   vpnId: string,
 ): Promise<{[key: string]: string}> {
-  try {
-    const response = await ec2Client.send(
-      new DescribeTagsCommand({
-        Filters: [{Name: 'resource-id', Values: [vpnId]}],
-      }),
-    );
-
-    const tags: {[key: string]: string} = {};
-    response.Tags?.forEach((tag) => {
-      if (tag.Key && tag.Value) {
-        tags[tag.Key] = tag.Value;
-      }
-    });
-
-    log
-      .info()
-      .str('function', 'fetchVpnTags')
-      .str('vpnId', vpnId)
-      .str('tags', JSON.stringify(tags))
-      .msg('Fetched tags for VPN');
-
-    return tags;
-  } catch (error) {
-    log
-      .error()
-      .str('function', 'fetchVpnTags')
-      .err(error)
-      .msg('Error fetching tags for VPN');
-    return {};
-  }
-}
-
-async function checkAndManageVpnStatusAlarms(
-  vpnId: string,
-  tags: Tag,
-): Promise<void> {
-  log
-    .info()
-    .str('function', 'checkAndManageVpnStatusAlarms')
-    .str('vpnId', vpnId)
-    .msg('Starting alarm management process');
-
-  const isAlarmEnabled = tags['autoalarm:enabled'] === 'true';
-  if (!isAlarmEnabled) {
-    log
-      .info()
-      .str('function', 'checkAndManageVpnStatusAlarms')
-      .str('vpnId', vpnId)
-      .msg('Alarm creation disabled by tag settings');
-    await deleteExistingAlarms('VPN', vpnId, metricConfigs);
-    return;
-  }
-
-  const alarmsToKeep = new Set<string>();
-
-  for (const config of metricConfigs) {
-    log
-      .info()
-      .str('function', 'checkAndManageVpnStatusAlarms')
-      .obj('config', config)
-      .str('vpnId', vpnId)
-      .msg('Processing metric configuration');
-
-    const tagValue = tags[`autoalarm:${config.tagKey}`];
-    const updatedDefaults = parseMetricAlarmOptions(
-      tagValue || '',
-      config.defaults,
-    );
-    if (config.defaultCreate || tagValue !== undefined) {
-      if (config.tagKey.includes('anomaly')) {
-        log
-          .info()
-          .str('function', 'checkAndManageVpnStatusAlarms')
-          .str('vpnId', vpnId)
-          .msg('Tag key indicates anomaly alarm. Handling anomaly alarms');
-        const anomalyAlarms = await handleAnomalyAlarms(
-          config,
-          'VPN',
-          vpnId,
-          [{Name: 'VpnId', Value: vpnId}],
-          updatedDefaults,
-        );
-        anomalyAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      } else {
-        log
-          .info()
-          .str('function', 'checkAndManageVpnStatusAlarms')
-          .str('vpnId', vpnId)
-          .msg('Tag key indicates static alarm. Handling static alarms');
-        const staticAlarms = await handleStaticAlarms(
-          config,
-          'VPN',
-          vpnId,
-          [{Name: 'VpnId', Value: vpnId}],
-          updatedDefaults,
-        );
-        staticAlarms.forEach((alarmName) => alarmsToKeep.add(alarmName));
-      }
-    } else {
-      log
-        .info()
-        .str('function', 'checkAndManageVpnStatusAlarms')
-        .str('vpnId', vpnId)
-        .str(
-          'alarm prefix: ',
-          buildAlarmName(
-            config,
-            'VPN',
-            vpnId,
-            AlarmClassification.Warning,
-            'static',
-          ).replace('Warning', ''),
-        )
-        .msg(
-          'No default or overridden alarm values. Marking alarms for deletion.',
-        );
-    }
-  }
-  // Delete alarms that are not in the alarmsToKeep set
-  // Restrict the prefix-based fetch to this resource's exact expected alarm
-  // names so we never delete alarms of another resource whose identifier
-  // shares a prefix.
-  const expectedAlarmNames = buildExpectedAlarmNames(
+  return fetchResourceTags(
     'VPN',
     vpnId,
-    metricConfigs,
-  );
-  const existingAlarms = (await getCWAlarmsForInstance('VPN', vpnId)).filter(
-    (alarm) => expectedAlarmNames.has(alarm),
-  );
-  const alarmsToDelete = existingAlarms.filter(
-    (alarm) => !alarmsToKeep.has(alarm),
-  );
+    async () => {
+      const response = await ec2Client.send(
+        new DescribeTagsCommand({
+          Filters: [{Name: 'resource-id', Values: [vpnId]}],
+        }),
+      );
 
-  log
-    .info()
-    .str('function', 'checkAndManageVpnStatusAlarms')
-    .obj('alarms to delete', alarmsToDelete)
-    .msg('Deleting alarms that are no longer needed');
-  await massDeleteAlarms(alarmsToDelete);
+      const tags: {[key: string]: string} = {};
+      response.Tags?.forEach((tag) => {
+        if (tag.Key && tag.Value) {
+          tags[tag.Key] = tag.Value;
+        }
+      });
 
-  log
-    .info()
-    .str('function', 'checkAndManageVpnStatusAlarms')
-    .str('vpnId', vpnId)
-    .msg('Finished alarm management process');
+      return tags;
+    },
+    'return-empty',
+  );
 }
 
 export async function manageVpnAlarms(vpnId: string, tags: Tag): Promise<void> {
-  await checkAndManageVpnStatusAlarms(vpnId, tags);
+  await manageServiceAlarms({
+    service: 'VPN',
+    identifier: vpnId,
+    tags,
+    configs: metricConfigs,
+    dimensions: [{Name: 'VpnId', Value: vpnId}],
+  });
 }
 
 export async function manageInactiveVpnAlarms(vpnId: string): Promise<void> {


### PR DESCRIPTION
Closes #236.

Pure consolidation — same behavior, one implementation. Net **−1,520 lines** (+849 / −2,369 across 18 files, including the new helper and its tests).

## What was extracted

New `handlers/src/alarm-configs/utils/service-helpers.mts`:

- **`manageServiceAlarms({service, identifier, tags, configs, dimensions, checkEnabled?})`** — the generic reconcile entry point implementing the shape previously copy-pasted as `checkAndManage<Service>StatusAlarms` in 13 modules: enabled-gate → `deleteExistingAlarms` path; else loop configs → `parseMetricAlarmOptions` → anomaly/static handler dispatch → `alarmsToKeep` set → `getCWAlarmsForInstance` + exact expected-name filtering → chunked `massDeleteAlarms` of not-kept alarms. `checkEnabled: false` lets modules that gate `autoalarm:enabled` in their event parser (ECS, log groups) skip the generic strict-`'true'` check.
- **`filterAlarmsToDelete(existing, expectedNames, keep)`** — the pure reconcile-diffing step, factored out for unit testing without a CloudWatch client.
- **`fetchResourceTags(service, resourceId, fetchFn, onError)`** — generic tag fetcher owning the log + error-handling contract. `onError: 'rethrow'` (default) preserves the post-#228 retry semantics; `'return-empty'` preserves the legacy modules that treated fetch errors as an empty tag set. All 14 `fetch<Service>Tags` wrappers now delegate, supplying only their SDK call + Tag extraction closure.
- **`findArnInEvent(event, arnPrefix)`** — the stringify-event/indexOf ARN extraction previously copied as `findRDSArn`, `findRDSClusterArn`, and inlined in the ECS and log-group identifier extractors.

In `alarm-tools.mts`, **`handleStaticAlarms` and `handleAnomalyAlarms` are now thin wrappers** over a single parameterized `handleAlarmsForVariant(variant: 'anomaly' | 'static', ...)`. Both exported names are kept, so no call sites changed (EC2 still calls them directly).

## Per-module conversion

| Module | Reconcile → `manageServiceAlarms` | Fetcher → `fetchResourceTags` | `findArnInEvent` |
|---|---|---|---|
| sqs | ✅ | ✅ rethrow | — |
| alb | ✅ | ✅ return-empty | — |
| rds | ✅ | ✅ rethrow | ✅ |
| rds-cluster | ✅ | ✅ rethrow | ✅ |
| cloudfront | ✅ | ✅ return-empty | — |
| opensearch | ✅ | ✅ return-empty | — |
| route53-resolver | ✅ | ✅ return-empty | — |
| step-function | ✅ | ✅ return-empty | — |
| targetgroup | ✅ (keeps LB guard, see below) | ✅ return-empty | — |
| transit-gateway | ✅ | ✅ return-empty | — |
| vpn | ✅ | ✅ return-empty | — |
| ecs | ✅ (`checkEnabled: false`) | ✅ rethrow | ✅ (ARN find step) |
| loggroup | ✅ (`checkEnabled: false`) | ✅ rethrow | ✅ (ARN find step) |
| **ec2** | **left bespoke** | ✅ rethrow | — |

**EC2 left bespoke** (per issue): its alarm management embeds storage paths and platform-resolved metric names in alarm names, drives Prometheus rule batching, and uses prefix-based reconciliation; only its tag fetcher was converted.

## Preserved behavioral deviations

- **ECS enabled-gate**: ECS's event parser treats any present `autoalarm:enabled` value other than `'false'` as enabled (vs. the strict `=== 'true'` everywhere else). Preserved via `checkEnabled: false` — the parser's gating is untouched.
- **Log-group enabled-gate** also stays in its parser (strict `'true'`), `checkEnabled: false` avoids double-checking.
- **Target group LB guard**: original code returned early (skipping reconcile-delete) when alarms were enabled but no load balancer was associated. Preserved with the same ordering: enabled-gate (delete path) wins; the guard only fires when enabled.
- **Fetcher error contracts**: the rethrow vs. return-`{}` split across modules is preserved exactly via the `onError` parameter (see table).
- **Inline `DeleteAlarmsCommand` reconcile blocks**: verified none remain in service modules — all were already converted to `massDeleteAlarms` by the prior PRs; this PR routes them through the shared helper.

## Normalizations (log-level only, no semantic change)

- Log function names/field labels unified to `manageServiceAlarms` with `Service`/`Identifier` fields (was per-module `checkAndManageXStatusAlarms` with `QueueName`/`dbInstanceId`/etc.). OpenSearch's `ClientId` log field dropped from the start/finish logs (still used as a dimension).
- The "no default or overridden values" log now records the config `tagKey` instead of a `buildAlarmName(...).replace('Warning','')` prefix (and no longer emits `buildAlarmName`'s own info log for that synthetic name).
- RDS / RDS-cluster / SFN debugging blocks (re-logging raw existing alarms and a per-alarm "matches expected pattern" loop) dropped — pure log noise, no control flow.
- ECS / log-group modules previously logged some per-config steps at `debug`; they now go through the shared `info`-level logs like every other module. Their fetchers' `debug` success logs are now the shared `info` "Fetched tags" log; `fetchLogGroupTags` (which had no try/catch) now also logs the error before rethrowing.
- `handleStaticAlarms`'s no-thresholds log had a hardcoded `AutoAlarm-ALB-` prefix bug — the message now uses the actual service. Anomaly creation message now says "alarms" (was singular) to match the static wording.
- Log-group's anomaly dispatch used `tagKey.includes('anomaly') || config.anomaly`; the shared helper uses the tagKey check only — verified equivalent: every shipped config has `anomaly: true` iff its tagKey contains `anomaly` (and this matches `buildExpectedAlarmNames`'s variant resolution).
- `findArnInEvent`'s not-found/extracted log messages are generic (include the searched prefix) instead of per-service wording; the ECS and log-group extractors keep their own not-found error logs on top.

## Tests / verification

- `handlers`: `tsc --noEmit` ✅, `eslint .` ✅, `prettier --check` ✅, `vitest` **29 passed** (21 existing unchanged + 8 new for `filterAlarmsToDelete` incl. prefix-collision safety against `buildExpectedAlarmNames` output, and `findArnInEvent`).
- `cdk`: `pnpm run build` ✅, `pnpm test` **8 passed**.