### PR TITLE
feat: add Lambda monitoring surface (alarm on function errors)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,19 @@
+# CLAUDE.md — AutoAlarm
+
+AutoAlarm is an event-driven AWS Lambda system that creates/updates/deletes CloudWatch alarms (and Prometheus rules) for ~14 service types based on resource tags. See `ARCHITECTURE.md` and `README.md` for behavior and the tag schema.
+
+## Surface testing
+
+When asked to **test the surfaces**, **test alarm creation/deletion**, **verify a refactor**, or **run the AutoAlarm test pattern**, follow **[`TESTING_PLAN.md`](./TESTING_PLAN.md)** — the prescriptive, step-by-step runbook for exercising every surface via tag/untag, resource create/destroy, the custom-tag → ALARM → Kinesis Firehose delivery path, and CloudWatch log verification. It is written to be run with the **TrueMark MCP gateway** + CloudWatch MCP. Default region `us-west-2` (CloudFront → `us-east-1`).
+
+### Non-negotiable test guardrails (full detail in `TESTING_PLAN.md` §1 and §11)
+- **Destroy only resources the agent itself created during the run.** Never delete/stop/reconfigure a pre-existing resource.
+- Stamp every created resource with `autoalarm-test:run-id=<RUN_ID>` and a `autoalarm-test-*` `Name`; record everything in `./.autoalarm-test/inventory-<RUN_ID>.json`. **Teardown trusts the inventory and nothing else.**
+- Before deleting any alarm, require **both** an `AutoAlarm-*` name match **and** an inventory-tracked test resource id.
+- For tag-only (pre-existing) resources, restore original tags exactly — remove only the keys you added.
+- **ReAlarm resets every ALARM-state alarm in the account by default**; set `autoalarm:re-alarm-enabled=false` on test alarms you don't want reset.
+
+## Layout
+- `handlers/src/` — Lambda handlers, `service-modules/`, `alarm-configs/` (one per surface).
+- `cdk/lib/` — stack + subconstructs (EventBridge rules, ReAlarm producer/consumer/tag-event, SQS handler).
+- `TESTING_PLAN.md` — the surface test runbook (start here for any testing task).

--- a/TESTING_PLAN.md
+++ b/TESTING_PLAN.md
@@ -1,0 +1,282 @@
+# AutoAlarm Post-Refactor Surface Test Plan
+
+> **Audience:** a Claude Code agent with access to the **TrueMark MCP gateway** (AWS read/inventory, CloudWatch logs/metrics/alarms, and break-glass write/deploy/Lambda-invoke).
+> **Goal:** after a refactor, exercise **every surface** of AutoAlarm by tagging/untagging resources to create and destroy alarms, by creating and destroying real resources to test the resource-lifecycle path, by driving a **custom-tag alarm into ALARM** to test alarm creation **and the EventBridge → Kinesis Firehose delivery path**, and by reading **all CloudWatch logs** to confirm logging behaves as expected.
+> **Primary region:** `us-west-2`. **CloudFront only:** `us-east-1` (its tag/CloudTrail events are delivered only there).
+
+---
+
+## 0. How to use this document
+
+Work top to bottom. Section 1 (Safety) is non-negotiable and governs everything else. Section 2 establishes the baseline you teardown back to. Sections 4–10 are the actual test passes. Section 11 is teardown. Section 12 is the pass/fail scorecard to fill in.
+
+Throughout, discover TrueMark MCP tools with `search_tools` → `get_tool_schema` → `invoke_tool`. Use the CloudWatch MCP (`describe_log_groups`, `execute_log_insights_query`, `get_active_alarms`, `get_alarm_history`, `get_metric_data`) for verification.
+
+---
+
+## 0.5 Gateway role — do this before any AWS operation
+
+All AWS write and read operations in this test run through **`AwsApiMcp___call_aws`** (the TrueMark gateway's AWS CLI bridge). The gateway runtime transparently assumes **`TrueMarkMcpGatewaySurfaceTestRole`** (account `999776382415`) — the agent does **not** call `sts:AssumeRole` itself; that happens inside the runtime.
+
+**Required on every `AwsApiMcp___call_aws` call:** append `--profile surfacetest` to activate the pre-configured surface-test credentials. Example:
+
+```
+aws ec2 describe-instances --region us-west-2 --profile surfacetest
+aws sqs create-queue --queue-name my-test-queue --region us-west-2 --profile surfacetest
+```
+
+**Verify at the start of §2:** confirm the caller identity is `TrueMarkMcpGatewaySurfaceTestRole`:
+
+```
+aws sts get-caller-identity --profile surfacetest
+```
+
+If the returned ARN does not contain `TrueMarkMcpGatewaySurfaceTestRole`, stop immediately and report the error — do not proceed under a different identity.
+
+---
+
+## 1. SAFETY GUARDRAILS — read first, enforce always
+
+These rules exist because the test runs against a live AWS account and because two AutoAlarm behaviors are intentionally broad.
+
+### 1.1 Destroy only what the agent created
+- **Never delete, stop, or destructively reconfigure any pre-existing AWS resource.** The only resources you may destroy are ones **you created during this run**.
+- Stamp every created resource with two markers at creation time:
+  - `autoalarm-test:run-id=<RUN_ID>` (a UUID/timestamp you generate at start)
+  - `Name=autoalarm-test-<surface>-<RUN_ID>`
+- Maintain an **inventory file** (`./.autoalarm-test/inventory-<RUN_ID>.json`) listing every resource ARN/ID you create and every alarm name AutoAlarm creates for it. **Teardown reads only from this inventory** — if it is not in the inventory, you do not touch it.
+
+### 1.2 For tag-only (pre-existing) resources, restore exactly
+- For slow/expensive surfaces you tag pre-existing resources instead of creating them (see §3). Before tagging, **record the resource's original tag set**. During teardown, remove only the `autoalarm:*` and `autoalarm-test:*` keys **you added**, and restore any pre-existing `autoalarm:*` tag value you overwrote. Never blanket-clear tags.
+
+### 1.3 Alarm deletion safety
+- Before deleting any alarm, confirm **both**: (a) the name matches `AutoAlarm-*`, **and** (b) it maps to a test resource id recorded in your inventory. Deleting an `AutoAlarm-*` alarm whose resource id is not in your inventory is forbidden.
+- AutoAlarm should delete alarms itself when you set `autoalarm:enabled=false` or remove the enable tag. Prefer letting AutoAlarm delete; only delete alarms directly during teardown for orphans tied to your test resource ids.
+
+### 1.4 ReAlarm caution (account-wide behavior)
+- **By default ReAlarm resets _every_ CloudWatch alarm in the account that is in `ALARM` state**, not just AutoAlarm's. Two consequences:
+  - Any test alarm you intentionally drive to `ALARM` may be reset by the scheduled ReAlarm (every 120 min) — account for this in timing.
+  - To prevent interference during a focused test, set `autoalarm:re-alarm-enabled=false` on test alarms you don't want reset.
+- Do **not** manually invoke the ReAlarm producer against the whole account casually; in §7 it is invoked deliberately and its account-wide effect is expected and noted.
+
+### 1.5 Cost / blast radius
+- Use the smallest instance/queue/domain sizes. Tear down promptly. Never create resources in production VPCs or with production-looking names — always the `autoalarm-test-*` naming.
+
+---
+
+## 2. Pre-flight: discover the deployment and capture a baseline
+
+1. **Confirm identity & region.** `get_me`-equivalent / STS caller identity; confirm account is the intended **test** account and region is `us-west-2`.
+2. **Locate the stack and its components** (via TrueMark MCP inventory tools):
+   - AutoAlarm Lambda functions (main handler; ReAlarm producer, consumer, tag-event handler; SQS handler).
+   - Their **CloudWatch log groups** — discover with `describe_log_groups` (prefix `/aws/lambda/` + filter on `AutoAlarm`/`autoalarm`). Record exact names; do not hardcode.
+   - The **per-service SQS queues and their `-Failed` DLQs**: `AutoAlarm-Alb`, `AutoAlarm-Cloudfront`, `AutoAlarm-Ec2`, `AutoAlarm-Ecs`, `AutoAlarm-Lambda`, `AutoAlarm-Logs`, `AutoAlarm-OpenSearchRule`, `AutoAlarm-Rds`, `AutoAlarm-RdsCluster`, `AutoAlarm-Route53resolver`, `AutoAlarm-Sqs`, `AutoAlarm-Sfn`, `AutoAlarm-TargetGroup`, `AutoAlarm-TransitGateway`, `AutoAlarm-Vpn` (each has a `*-Failed` DLQ).
+   - The **EventBridge rules** routing each service's tag/state/CloudTrail events.
+   - The **Kinesis Firehose delivery stream** that ingests EventBridge events, and its destination (e.g., S3 bucket). Record stream name + destination — needed for §6 delivery verification.
+   - Whether a **`prometheusWorkspaceId`** context/env was set at deploy (determines whether §8 applies).
+3. **Baseline snapshots** (store in `./.autoalarm-test/baseline-<RUN_ID>.json`):
+   - All existing `AutoAlarm-*` alarms (names + state). This is what teardown must return to.
+   - DLQ approximate message counts (should be ~0).
+   - Current depth of the Firehose destination (so new records are attributable).
+4. Record `RUN_ID` and a UTC `START_TIME` (used as the lower bound for all log/metric queries).
+
+---
+
+## 3. Surface matrix — what to test and how to instantiate it
+
+AutoAlarm is fully event-driven. Each surface is triggered by **tag-change events** and/or **CloudTrail create/delete events**. "Create method" reflects the **cheap-real / tag-only-slow** strategy.
+
+| # | Surface | EventBridge trigger(s) | Create method | Resource identifier in alarm name |
+|---|---------|------------------------|---------------|-----------------------------------|
+| 1 | **EC2** instance | `aws.tag` Tag Change (instance) + EC2 Instance State-change | **Create real** (t-class, smallest) | instance id |
+| 2 | **SQS** queue | CloudTrail `CreateQueue`/`DeleteQueue`/`TagQueue`/`UntagQueue` | **Create real** | queue name |
+| 3 | **CloudWatch Log Group** | CloudTrail `CreateLogGroup`/`DeleteLogGroup`/`TagResource`/`UntagResource` | **Create real** | log group name |
+| 4 | **Step Functions** state machine | `aws.tag` (stateMachine) + CloudTrail `CreateStateMachine`/`DeleteStateMachine` | **Create real** (trivial state machine) | state machine name |
+| 5 | **ECS** | CloudTrail create/delete + `TagResource`/`UntagResource` | **Create real** (empty cluster) | cluster/service id |
+| 6 | **Target Group** | `aws.tag` (targetgroup) + CloudTrail `CreateTargetGroup`/`DeleteTargetGroup` | **Create real** (note: TG metrics require ALB association) | target group id |
+| 7 | **ALB** | `aws.tag` (loadbalancer) + CloudTrail `CreateLoadBalancer`/`DeleteLoadBalancer` | Create real **only if** a test VPC/subnets exist; else tag-only | LB id |
+| 8 | **CloudFront** distribution | `aws.cloudfront` `CreateDistribution`/`DeleteDistribution` + `aws.tag` (distribution) | **Tag-only**, and **in `us-east-1`** | distribution id |
+| 9 | **OpenSearch** domain | `aws.tag` (domain) + `aws.es` `CreateDomain`/`DeleteDomain` | **Tag-only** (slow/expensive) | domain name |
+| 10 | **RDS** instance | `aws.tag` (db) + `aws.rds` `CreateDBInstance`/`DeleteDBInstance` | **Tag-only** | db id |
+| 11 | **RDS Cluster** | `aws.tag` (cluster) + `aws.rds` `CreateDBCluster`/`DeleteDBCluster` | **Tag-only** | cluster id |
+| 12 | **Route53 Resolver** endpoint | `aws.tag` (resolver-endpoint) + `aws.route53resolver` `CreateResolverEndpoint`/`DeleteResolverEndpoint` | **Tag-only** | endpoint id |
+| 13 | **Transit Gateway** | `aws.tag` (transit-gateway) + `aws.ec2` `CreateTransitGateway`/`DeleteTransitGateway` | **Tag-only** | tgw id |
+| 14 | **VPN** connection | `aws.tag` (vpn-connection) + `aws.ec2` `CreateVpnConnection`/`DeleteVpnConnection` | **Tag-only** | vpn id |
+| 15 | **Lambda** function | `aws.tag` (function) + CloudTrail `CreateFunction`/`DeleteFunction` (legacy `…20150331` **and** current `…20150331v2` — Lambda's current events carry the `v2` suffix, verified via a live CloudTrail record) | **Create real** (trivial inline-Node function) | function name |
+
+> **Lambda surface note:** only one default alarm is created — `Errors` (Sum, critical threshold `1`, 60s/1 period, `defaultCreate: true`). So `autoalarm:enabled=true` alone yields `AutoAlarm-Lambda-<fn>-Errors-Critical`; there is **no** Warning alarm by default and no other metric. Custom case (B) reconfigures via `autoalarm:errors=<8-field value>`; nullish case (C) is `autoalarm:errors=-/-/…` (both thresholds `-`) → the errors alarm is removed. To drive ALARM (for §6-style checks), invoke the function so it throws once.
+
+> **Surfaces worth extra scrutiny post-refactor:** **ECS** and **CloudWatch Log Group** appear in the handler/config code but are *not* in the README's "Supported Services" list — confirm they actually create/destroy alarms as expected. Also re-verify the recently-fixed areas: **main-handler batch processing**, **alarm-deletion-safety**, and **resource-id-extraction** (see §9).
+
+---
+
+## 4. Tag schema reference (how you trigger each behavior)
+
+- **Enable:** `autoalarm:enabled=true` → creates all default alarms for the resource. **Required.**
+- **Disable:** `autoalarm:enabled=false` **or remove the tag** → deletes all AutoAlarm-managed alarms (default + custom) for that resource.
+- **EC2 target selection:** `autoalarm:target=cloudwatch` | `prometheus` (see §8).
+- **ReAlarm:** `autoalarm:re-alarm-enabled=false` (opt out); `autoalarm:re-alarm-minutes=<5..1440>` (custom interval; out-of-range is invalid and removes any per-alarm schedule).
+- **Custom alarm tag value** — 8 `/`-separated fields:
+  `warnThreshold / critThreshold / periodSec / evalPeriods / statistic / datapointsToAlarm / comparisonOperator / treatMissingData`
+  Example: `autoalarm:cpu=66/89/120/15/Average/12/GreaterThanOrEqualToThreshold/breaching`
+- **Nullish `-`:** a `-` in the warn or crit threshold position disables *that* threshold's alarm. If **both** warn and crit are `-`, **no alarm** is created for that metric.
+
+**Expected alarm name patterns** (verify with these):
+- Static: `AutoAlarm-<SERVICE>-<identifier>-<MetricName>-<Warning|Critical>`
+- Anomaly: `AutoAlarm-<SERVICE>-<identifier>-<MetricName>-anomaly-<Warning|Critical>`
+- (Storage-path variants insert `-<storagePath>-` before the classification.)
+
+---
+
+## 5. Core test pattern — run for each surface in §3
+
+For each surface, execute cases **A–G**. After each tag mutation, **poll** (don't fixed-sleep): re-list `AutoAlarm-<SERVICE>-<id>-*` alarms every ~15s up to a 3–5 min ceiling before declaring fail (event → EventBridge → SQS → Lambda has latency).
+
+- **A. Enable → create.** Set `autoalarm:enabled=true`. Assert the service's **default** alarms now exist with the expected names. Record them in inventory.
+- **B. Custom reconfigure.** Set one custom metric tag (e.g. `autoalarm:cpu=70/90/60/5/Average/5/GreaterThanThreshold/missing`). Assert the corresponding alarm's threshold/period/eval-periods/comparison/missing-data **updated** to match (read alarm definition; don't just check existence).
+- **C. Nullish.** Set the same metric tag with both thresholds `-` (e.g. `autoalarm:cpu=-/-/60/5/Average/5/GreaterThanThreshold/missing`). Assert that metric's alarms are **removed**.
+- **D. Disable via `false`.** Set `autoalarm:enabled=false`. Assert **all** managed alarms for the resource are deleted.
+- **E. Re-enable, then untag.** Set `=true` (alarms return), then **remove** the `autoalarm:enabled` tag entirely. Assert all managed alarms are deleted (removal path, distinct from `=false`).
+- **F. Deletion-safety isolation.** While the resource's alarms exist, confirm that disabling/deleting it left the **baseline** alarms (§2) and any *other* test resources' alarms **untouched**. (Critical for the prefix-collision fix — see §9.)
+
+Then the **resource-lifecycle** cases (the "newly created / destroyed resource" requirement) — run on the **cheap-real** surfaces (EC2, SQS, Log Group, Step Functions, ECS, Target Group, Lambda):
+
+- **G1. Create-with-tag.** Create the resource **already carrying** `autoalarm:enabled=true`. Assert alarms are auto-created off the **creation** event (no manual tagging step).
+- **G2. Destroy.** Delete the (agent-created) resource. Assert AutoAlarm auto-deletes its alarms off the **deletion** event, and that nothing else was affected.
+
+> For **tag-only** surfaces (CloudFront, OpenSearch, RDS, RDS Cluster, Route53 Resolver, TGW, VPN): run A–F against a pre-existing resource. Document G1/G2 as **manual** steps (the create/destroy of, e.g., an RDS instance) rather than executing them, unless a disposable test instance already exists — and if you do create one, it goes in the inventory and gets torn down.
+
+---
+
+## 6. Alert TRIGGER + DELIVERY test (EventBridge → Kinesis Firehose)
+
+AutoAlarm alarms intentionally carry **no alarm actions** — delivery is observed by routing the CloudWatch **alarm-state-change** EventBridge event into a **Kinesis Firehose**. This test confirms an alarm is both **created** and that its state change is **delivered** through the Firehose.
+
+Use **EC2** as the delivery canary (cheap, controllable, real metrics).
+
+1. On the test EC2 instance set a custom tag whose threshold **breaches immediately** so the alarm goes to `ALARM` within one period — e.g.
+   `autoalarm:cpu=0/0/60/1/Average/1/GreaterThanOrEqualToThreshold/missing`
+   (CPU ≥ 0 is always true; 60s period, 1 datapoint → fastest possible breach). If the metric path can't be forced this way, fall back to driving real load, **not** to `SetAlarmState` (we want a genuine metric-driven transition for the delivery test).
+2. Assert the alarm was **created** (name + definition) and then transitions to **`ALARM`** — confirm via `get_alarm_history` (StateUpdate to ALARM) and `get_active_alarms`.
+3. **Delivery verification (the Firehose path):**
+   - Confirm the alarm-state-change produced an EventBridge event and that the **Firehose `IncomingRecords`/`IncomingBytes`** metrics incremented in the window around the transition (`get_metric_data` on the delivery stream).
+   - Inspect the Firehose **destination** (e.g., the S3 bucket/prefix recorded in §2) for a newly-written record whose payload contains the **alarm name** and `"state":"ALARM"`. Confirm `DeliveryToS3.Success` (or destination-appropriate) metric is non-zero for the window.
+   - Note `autoalarm:re-alarm-enabled=false` on this alarm during the test so the scheduled ReAlarm doesn't perturb the transition mid-verification.
+4. **Clear & confirm deletion path:** set `autoalarm:enabled=false`, assert the alarm is deleted.
+5. Record: alarm-created ✓/✗, reached ALARM ✓/✗, Firehose ingested record ✓/✗, payload contained alarm name ✓/✗.
+
+---
+
+## 7. ReAlarm subsystem
+
+Components: **producer** (scheduled ~120 min), **consumer**, **tag-event handler**. Because waiting 2 hours is impractical, invoke the **producer Lambda manually** (break-glass invoke via TrueMark MCP). Remember §1.4: this acts on **all** ALARM-state alarms account-wide.
+
+- **R1. Reset behavior.** With a test alarm in `ALARM` (from §6 setup), invoke the producer; assert the alarm is reset (`SetAlarmState` to `OK`/`INSUFFICIENT_DATA`, visible in `get_alarm_history`) and re-evaluates.
+- **R2. Opt-out.** Set `autoalarm:re-alarm-enabled=false` on a second ALARM-state test alarm; invoke producer; assert it is **skipped**.
+- **R3. Custom interval.** Set `autoalarm:re-alarm-minutes=15` (valid) on a test alarm; assert a per-alarm 15-min schedule is created (inspect the schedule/rule the tag-event handler manages). Then set `autoalarm:re-alarm-minutes=3` (invalid, <5) and `=2000` (invalid, >1440); assert each is treated as invalid and any existing per-alarm schedule is **removed**.
+- **R4. AutoScaling exclusion.** Confirm an alarm tied to an AutoScaling action is **never** reset (if no ASG exists, document as not-tested rather than fabricating one).
+- **R5. Logs.** Confirm producer/consumer/tag-event handler log groups show the decisions above (see §10).
+
+---
+
+## 8. Prometheus path (EC2 only) — run **only if** `prometheusWorkspaceId` was set at deploy
+
+- **P1. Prefer-Prometheus.** With a workspace configured and the EC2 instance **reporting** to AMP, enable AutoAlarm; assert **Prometheus alert rules** (CPU/Memory/Storage) are created and that any pre-existing **CloudWatch** alarms for that instance are **deleted**.
+- **P2. Force CloudWatch.** Set `autoalarm:target=cloudwatch`; assert CloudWatch alarms are used instead.
+- **P3. Fallback.** Set `autoalarm:target=prometheus` on an instance **not** reporting to AMP; assert AutoAlarm detects this and **falls back to CloudWatch** alarms.
+- Verify AMP rule groups via the CloudWatch MCP PromQL tools / AMP rule-group inspection. If `prometheusWorkspaceId` is unset, mark §8 **N/A** in the scorecard.
+
+---
+
+## 9. Negative / edge cases (to unearth bugs — emphasize refactor-touched areas)
+
+- **E1. Invalid tag values.** Bad comparison operator, non-numeric threshold, malformed 8-field value, out-of-range period. Assert: schema validation rejects gracefully, a clear error is **logged**, no malformed alarm is created, and (if applicable) the event lands in the service's **`-Failed` DLQ** rather than crashing the handler.
+- **E2. Prefix-collision / resource-id-extraction (recent fix).** Create two resources whose identifiers **share a prefix** (e.g., a queue `orders` and `orders-2`, or instances/log groups with shared-prefix names). Enable both, then disable **one**. Assert **only** the disabled resource's alarms are deleted and the sibling's survive. (This is the alarm-deletion-safety / resource-id-extraction guarantee.)
+- **E3. Empty identifier guard.** Confirm the handler **refuses to delete alarms by service prefix when the identifier is empty** (look for the "Refusing to delete alarms by service prefix" log line) — i.e., no mass deletion on a bad/empty id.
+- **E4. Batch processing (recent fix).** Tag many resources in rapid succession (e.g., 10+ SQS queues or log groups at once). Assert the main handler processes **all** of them (no dropped messages), DLQs stay empty, and alarms appear for every resource.
+- **E5. Target Group without ALB.** Tag a target group not associated with an ALB; confirm AutoAlarm's documented behavior (TG metrics require ALB association) — alarms that depend on association behave as designed, not erroring silently.
+- **E6. CloudFront region.** Confirm that tagging a CloudFront distribution while operating in **`us-west-2`** produces **no** events (events arrive only in `us-east-1`); run the actual CloudFront case in `us-east-1`. Documents the region constraint explicitly.
+- **E7. Re-enable idempotency.** Enable an already-enabled resource / disable an already-disabled one; assert no duplicate alarms and no errors.
+
+---
+
+## 10. Logging verification (read all CloudWatch logs)
+
+For **every** AutoAlarm Lambda log group discovered in §2 (main handler, ReAlarm producer/consumer/tag-event, SQS handler), query the window `[START_TIME, now]`:
+
+- Use `execute_log_insights_query` filtered on your `RUN_ID`, the test resource ids, and the alarm names. For each surface case A–G assert a corresponding **create/update/delete decision** was logged.
+- Assert **no unexpected `ERROR`/exception** lines (the only errors should be the intentional ones from §9 E1, and those should be structured, not stack-crash traces).
+- Confirm **each tag/CloudTrail event was processed** (no silent drops) and that **DLQs are empty** (or contain only the deliberately-failed E1 events).
+- Spot-check that the **refactor-touched code paths** (batch processing, deletion-safety guard, resource-id extraction) emit the expected log lines.
+- Save raw query results to `./.autoalarm-test/logs-<RUN_ID>/` per log group.
+
+---
+
+## 11. Teardown (inventory-driven; destroy only agent-created resources)
+
+Execute in this order, reading **only** from `inventory-<RUN_ID>.json`:
+
+1. For each tag-only resource: remove the `autoalarm:*` / `autoalarm-test:*` keys **you added** and **restore** any original `autoalarm:*` value you overwrote (per §1.2). Let AutoAlarm delete the alarms.
+2. For each agent-created resource: set `autoalarm:enabled=false` (let AutoAlarm delete alarms), then **delete the resource itself**.
+3. Delete any **orphan** `AutoAlarm-*` alarms that are in the inventory but still present (match name `AutoAlarm-*` **and** a test resource id).
+4. Confirm **DLQs** are back to baseline depth (purge only the deliberately-failed E1 test messages if needed).
+5. **Final assertion:** the set of `AutoAlarm-*` alarms equals the §2 **baseline** — no orphaned test alarms remain — and no non-test resource was modified.
+
+---
+
+## 12. Results scorecard (fill in)
+
+| Surface | A enable | B custom | C nullish | D disable=false | E untag | F isolation | G create→destroy | Logs OK |
+|---|---|---|---|---|---|---|---|---|
+| EC2 | | | | | | | | |
+| SQS | | | | | | | | |
+| Log Group | | | | | | | | |
+| Step Functions | | | | | | | | |
+| ECS | | | | | | | | |
+| Target Group | | | | | | | | |
+| Lambda | | | | | | | | |
+| ALB | | | | | | | (manual) | |
+| CloudFront (us-east-1) | | | | | | | (manual) | |
+| OpenSearch | | | | | | | (manual) | |
+| RDS | | | | | | | (manual) | |
+| RDS Cluster | | | | | | | (manual) | |
+| Route53 Resolver | | | | | | | (manual) | |
+| Transit Gateway | | | | | | | (manual) | |
+| VPN | | | | | | | (manual) | |
+
+**Cross-cutting:**
+
+| Test | Result | Notes |
+|---|---|---|
+| §6 Custom-tag alarm created | | |
+| §6 Reached ALARM | | |
+| §6 Firehose ingested the state-change record | | |
+| §6 Disable deletes the alarm | | |
+| §7 R1 reset / R2 opt-out / R3 interval / R4 ASG-exclusion | | |
+| §8 Prometheus P1/P2/P3 (or N/A) | | |
+| §9 E1 invalid→DLQ / E2 prefix-collision / E3 empty-id guard / E4 batch / E5 TG / E6 CF region / E7 idempotency | | |
+| §10 All log groups clean; DLQs empty | | |
+| §11 Alarm set returned to baseline; no non-test resource modified | | |
+
+---
+
+## Appendix A — TrueMark MCP discovery hints
+- `gateway_manifest` → see gateways. `search_tools("create EC2 instance")`, `search_tools("tag resource")`, `search_tools("invoke lambda")`, `search_tools("kinesis firehose metrics")`, `search_tools("describe alarms")` → `get_tool_schema` → `invoke_tool`.
+- CloudWatch MCP: `describe_log_groups`, `execute_log_insights_query`, `get_active_alarms`, `get_alarm_history`, `get_metric_data`, PromQL tools for AMP.
+
+## Appendix B — Tag cheat-sheet
+```
+autoalarm:enabled = true | false            # master switch (remove = also deletes)
+autoalarm:target  = cloudwatch | prometheus  # EC2 only
+autoalarm:re-alarm-enabled = false           # per-alarm ReAlarm opt-out
+autoalarm:re-alarm-minutes = 5..1440         # per-alarm ReAlarm interval (out-of-range = invalid)
+autoalarm:<metric> = warn/crit/period/evalPeriods/stat/datapoints/comparisonOp/treatMissingData
+#   '-' in warn or crit disables that threshold; both '-' = no alarm for that metric
+```
+
+## Appendix C — Run-id markers
+```
+autoalarm-test:run-id = <RUN_ID>
+Name = autoalarm-test-<surface>-<RUN_ID>
+```
+Inventory & baseline live under ./.autoalarm-test/ keyed by RUN_ID. Teardown trusts the inventory and nothing else.

--- a/cdk/lib/auto-alarm.test.ts
+++ b/cdk/lib/auto-alarm.test.ts
@@ -18,16 +18,16 @@ beforeAll(() => {
 
 describe('AutoAlarm stack', () => {
   test('creates the expected number of SQS queues', () => {
-    // 14 service queues + 14 service DLQs + main handler queue + DLQ +
+    // 15 service queues + 15 service DLQs + main handler queue + DLQ +
     // ReAlarm consumer queue + DLQ + ReAlarm tag event queue + DLQ
-    // + 1 shared EventBridge rule target DLQ (standard) = 35
-    template.resourceCountIs('AWS::SQS::Queue', 35);
+    // + 1 shared EventBridge rule target DLQ (standard) = 37
+    template.resourceCountIs('AWS::SQS::Queue', 37);
   });
 
   test('every EventBridge rule has at least one target', () => {
     const rules = template.findResources('AWS::Events::Rule');
     const ruleEntries = Object.entries(rules);
-    // 25 service rules + ReAlarm schedule rule + ReAlarm tag rule
+    // 27 service rules + ReAlarm schedule rule + ReAlarm tag rule
     expect(ruleEntries.length).toBeGreaterThanOrEqual(27);
     for (const [logicalId, rule] of ruleEntries) {
       const targets = rule.Properties?.Targets ?? [];
@@ -126,9 +126,9 @@ describe('AutoAlarm stack', () => {
     const queuesWithRedrive = queues.filter(
       (queue) => queue.Properties?.RedrivePolicy !== undefined,
     );
-    // main handler queue + 14 service queues + ReAlarm consumer queue +
+    // main handler queue + 15 service queues + ReAlarm consumer queue +
     // ReAlarm tag event queue
-    expect(queuesWithRedrive.length).toBe(17);
+    expect(queuesWithRedrive.length).toBe(18);
     for (const queue of queuesWithRedrive) {
       expect(queue.Properties.RedrivePolicy.maxReceiveCount).toBe(3);
       // ~6x the 900s consumer Lambda timeout per AWS guidance
@@ -140,8 +140,8 @@ describe('AutoAlarm stack', () => {
     const mappings = Object.values(
       template.findResources('AWS::Lambda::EventSourceMapping'),
     );
-    // 14 service queues + main handler + ReAlarm consumer + ReAlarm tag event
-    expect(mappings.length).toBeGreaterThanOrEqual(17);
+    // 15 service queues + main handler + ReAlarm consumer + ReAlarm tag event
+    expect(mappings.length).toBeGreaterThanOrEqual(18);
     for (const mapping of mappings) {
       expect(mapping.Properties?.FunctionResponseTypes).toEqual([
         'ReportBatchItemFailures',

--- a/cdk/lib/main-function-subsconstruct.ts
+++ b/cdk/lib/main-function-subsconstruct.ts
@@ -333,6 +333,16 @@ export class AutoAlarm extends Construct {
       }),
     );
 
+    // Attach policies for Lambda to read function tags (ListTags) so AutoAlarm
+    // can manage alarms for tagged functions.
+    autoAlarmExecutionRole.addToPolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['lambda:ListTags', 'lambda:GetFunction'],
+        resources: ['*'],
+      }),
+    );
+
     return autoAlarmExecutionRole;
   }
 

--- a/cdk/lib/main-function-subsconstruct.ts
+++ b/cdk/lib/main-function-subsconstruct.ts
@@ -333,12 +333,13 @@ export class AutoAlarm extends Construct {
       }),
     );
 
-    // Attach policies for Lambda to read function tags (ListTags) so AutoAlarm
-    // can manage alarms for tagged functions.
+    // Attach policy for Lambda to read function tags (ListTags) so AutoAlarm
+    // can manage alarms for tagged functions. Only ListTags is needed — the
+    // handler never calls GetFunction (tags come from the ListTags response).
     autoAlarmExecutionRole.addToPolicy(
       new PolicyStatement({
         effect: Effect.ALLOW,
-        actions: ['lambda:ListTags', 'lambda:GetFunction'],
+        actions: ['lambda:ListTags'],
         resources: ['*'],
       }),
     );

--- a/cdk/lib/service-eventbridge-subconstruct.ts
+++ b/cdk/lib/service-eventbridge-subconstruct.ts
@@ -10,6 +10,7 @@ export type ServiceName =
   | 'cloudfront'
   | 'ec2'
   | 'ecs'
+  | 'lambda'
   | 'logs'
   | 'opensearch'
   | 'rds'
@@ -169,6 +170,35 @@ export const SERVICE_DESCRIPTORS: ServiceDescriptor[] = [
           'CreateService',
           'TagResource',
           'UntagResource',
+        ]),
+      },
+    ],
+  },
+  {
+    serviceName: 'lambda',
+    queueKey: 'AutoAlarm-Lambda',
+    rules: [
+      {
+        id: 'LambdaTagRule',
+        description: 'Routes Lambda tag events to AutoAlarm',
+        eventPattern: tagChangePattern(
+          'lambda',
+          'function',
+          SERVICE_TAG_KEYS.lambda,
+        ),
+      },
+      {
+        id: 'LambdaStateRule',
+        description: 'Routes Lambda function events to AutoAlarm',
+        // Current Lambda management events carry a "...v2" suffix (verified
+        // against a live us-west-2 CloudTrail record: TagResource20170331v2);
+        // match both the legacy and v2 names so the rule fires regardless of
+        // which the account emits.
+        eventPattern: cloudTrailPattern('aws.lambda', 'lambda.amazonaws.com', [
+          'CreateFunction20150331',
+          'CreateFunction20150331v2',
+          'DeleteFunction20150331',
+          'DeleteFunction20150331v2',
         ]),
       },
     ],

--- a/cdk/lib/service-tag-keys.test.ts
+++ b/cdk/lib/service-tag-keys.test.ts
@@ -40,6 +40,7 @@ const CONFIG_EXPORTS: Record<TagRuleService, string> = {
   alb: 'ALB_CONFIGS',
   cloudfront: 'CLOUDFRONT_CONFIGS',
   ec2: 'EC2_CONFIGS',
+  lambda: 'LAMBDA_CONFIGS',
   opensearch: 'OPENSEARCH_CONFIGS',
   rds: 'RDS_CONFIGS',
   rdscluster: 'RDS_CLUSTER_CONFIGS',

--- a/cdk/lib/service-tag-keys.ts
+++ b/cdk/lib/service-tag-keys.ts
@@ -26,6 +26,7 @@ export type TagRuleService =
   | 'alb'
   | 'cloudfront'
   | 'ec2'
+  | 'lambda'
   | 'opensearch'
   | 'rds'
   | 'rdscluster'
@@ -81,6 +82,7 @@ export const SERVICE_TAG_KEYS: Record<TagRuleService, string[]> = {
     'autoalarm:network-out-anomaly',
     'autoalarm:target',
   ],
+  lambda: ['autoalarm:enabled', 'autoalarm:errors'],
   opensearch: [
     'autoalarm:enabled',
     'autoalarm:4xx-errors',

--- a/cdk/lib/sqs-handler-subconstruct.ts
+++ b/cdk/lib/sqs-handler-subconstruct.ts
@@ -98,6 +98,7 @@ export class SqsHandlerSubConstruct extends Construct {
       'AutoAlarm-Cloudfront',
       'AutoAlarm-Ec2',
       'AutoAlarm-Ecs',
+      'AutoAlarm-Lambda',
       'AutoAlarm-Logs',
       'AutoAlarm-OpenSearchRule',
       'AutoAlarm-Rds',

--- a/handlers/package.json
+++ b/handlers/package.json
@@ -18,7 +18,7 @@
     "@aws-sdk/client-ecs": "^3.934.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.799.0",
     "@aws-sdk/client-eventbridge": "^3.800.0",
-    "@aws-sdk/client-lambda": "^3.799.0",
+    "@aws-sdk/client-lambda": "3.934.0",
     "@aws-sdk/client-opensearch": "^3.799.0",
     "@aws-sdk/client-rds": "^3.799.0",
     "@aws-sdk/client-resource-groups-tagging-api": "^3.799.0",

--- a/handlers/package.json
+++ b/handlers/package.json
@@ -18,6 +18,7 @@
     "@aws-sdk/client-ecs": "^3.934.0",
     "@aws-sdk/client-elastic-load-balancing-v2": "^3.799.0",
     "@aws-sdk/client-eventbridge": "^3.800.0",
+    "@aws-sdk/client-lambda": "^3.799.0",
     "@aws-sdk/client-opensearch": "^3.799.0",
     "@aws-sdk/client-rds": "^3.799.0",
     "@aws-sdk/client-resource-groups-tagging-api": "^3.799.0",

--- a/handlers/pnpm-lock.yaml
+++ b/handlers/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@aws-sdk/client-eventbridge':
         specifier: ^3.800.0
         version: 3.934.0
+      '@aws-sdk/client-lambda':
+        specifier: ^3.799.0
+        version: 3.1067.0
       '@aws-sdk/client-opensearch':
         specifier: ^3.799.0
         version: 3.934.0
@@ -182,6 +185,10 @@ packages:
   '@aws-sdk/client-eventbridge@3.934.0':
     resolution: {integrity: sha512-SHsGlW/+e580RlsVJ1K+MwVseEHbWMvXvhAM7XSA/zl2SgFxHpqHjNFR9V5E4bHxljeVAosspdAmi+NVJMffvQ==}
     engines: {node: '>=18.0.0'}
+
+  '@aws-sdk/client-lambda@3.1067.0':
+    resolution: {integrity: sha512-G3Prp8h1ay9XHZFHY+cOu7FwfoRAPLzO4b6Pa9JiHLtDBe8mqQwUs/pIlAIG5A49Ozg35v05IJgh/IoGmaCamw==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/client-opensearch@3.934.0':
     resolution: {integrity: sha512-QQ50OkZwPi07KSO7XP7agIjgswnON5/Wc2w5yJOlDJs/TxVNDij/uDWgECvOpzct77SQGpye1eX8JbEPWkQBWg==}
@@ -3045,6 +3052,19 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
+
+  '@aws-sdk/client-lambda@3.1067.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.974.20
+      '@aws-sdk/credential-provider-node': 3.972.55
+      '@aws-sdk/types': 3.973.12
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
+      tslib: 2.8.1
 
   '@aws-sdk/client-opensearch@3.934.0':
     dependencies:

--- a/handlers/pnpm-lock.yaml
+++ b/handlers/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^3.800.0
         version: 3.934.0
       '@aws-sdk/client-lambda':
-        specifier: ^3.799.0
-        version: 3.1067.0
+        specifier: 3.934.0
+        version: 3.934.0
       '@aws-sdk/client-opensearch':
         specifier: ^3.799.0
         version: 3.934.0
@@ -55,7 +55,7 @@ importers:
         version: 3.934.0
       '@aws-sdk/credential-provider-node':
         specifier: ^3.799.0
-        version: 3.934.0
+        version: 3.972.55
       '@aws-sdk/util-arn-parser':
         specifier: ^3.723.0
         version: 3.893.0
@@ -173,6 +173,7 @@ packages:
   '@aws-sdk/client-ec2@3.934.0':
     resolution: {integrity: sha512-VMTBq5zYkgDAz2a+EI0E/ALZgNamS3223jwFXksfHAujc91xhqzmiknl1Tpu60W2KgJGxRrX5f5mcSBZEHismw==}
     engines: {node: '>=18.0.0'}
+    deprecated: upgrade to @aws-sdk/client-ec2 v3.989.0+ for a serialization fix. Info at https://github.com/aws/aws-sdk-js-v3/pull/7734.
 
   '@aws-sdk/client-ecs@3.934.0':
     resolution: {integrity: sha512-KACaYDYW3nfYXRCJjs0Dp5FvQuQkw/PvKuQbuhB3CVLnfyoRCY2UnNQZ9YrlqCAfz8R6C2sZ2ygfOUMX7qzDng==}
@@ -186,9 +187,9 @@ packages:
     resolution: {integrity: sha512-SHsGlW/+e580RlsVJ1K+MwVseEHbWMvXvhAM7XSA/zl2SgFxHpqHjNFR9V5E4bHxljeVAosspdAmi+NVJMffvQ==}
     engines: {node: '>=18.0.0'}
 
-  '@aws-sdk/client-lambda@3.1067.0':
-    resolution: {integrity: sha512-G3Prp8h1ay9XHZFHY+cOu7FwfoRAPLzO4b6Pa9JiHLtDBe8mqQwUs/pIlAIG5A49Ozg35v05IJgh/IoGmaCamw==}
-    engines: {node: '>=20.0.0'}
+  '@aws-sdk/client-lambda@3.934.0':
+    resolution: {integrity: sha512-SKcyObNn0RM7hWUktsnD7nUmuYctLZjZnr29hDQOoptaF91SFPb1gEvUK908+5n5rSSj1NwHbJjoevA3pjE6BA==}
+    engines: {node: '>=18.0.0'}
 
   '@aws-sdk/client-opensearch@3.934.0':
     resolution: {integrity: sha512-QQ50OkZwPi07KSO7XP7agIjgswnON5/Wc2w5yJOlDJs/TxVNDij/uDWgECvOpzct77SQGpye1eX8JbEPWkQBWg==}
@@ -485,10 +486,6 @@ packages:
   '@aws-sdk/xml-builder@3.972.29':
     resolution: {integrity: sha512-fk0niuGFxfi8yIJuMVM4mhwObkiQSuwZFj3tAPrLVx64Pk3BkrEIpqjzHKY4hKoEBUD6Jg/S74Zj9jy+5F3DnQ==}
     engines: {node: '>=20.0.0'}
-
-  '@aws/lambda-invoke-store@0.2.0':
-    resolution: {integrity: sha512-D1jAmAZQYMoPiacfgNf7AWhg3DFN3Wq/vQv3WINt9znwjzHp2x+WzdJFxxj7xZL7V1U79As6G8f7PorMYWBKsQ==}
-    engines: {node: '>=18.0.0'}
 
   '@aws/lambda-invoke-store@0.2.4':
     resolution: {integrity: sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==}
@@ -891,6 +888,9 @@ packages:
 
   '@sinonjs/text-encoding@0.7.3':
     resolution: {integrity: sha512-DE427ROAphMQzU4ENbliGYrBSYPXF+TtLg9S8vzeA+OF4ZKzoDdzfL8sxuMUGS/lgRhM6j1URSk9ghf7Xo1tyA==}
+    deprecated: |-
+      Deprecated: no longer maintained and no longer used by Sinon packages. See
+        https://github.com/sinonjs/nise/issues/243 for replacement details.
 
   '@smithy/abort-controller@3.1.9':
     resolution: {integrity: sha512-yiW0WI30zj8ZKoSYNx90no7ugVn3khlyH/z5W8qtKBtVE6awRALbhSG+2SAHA1r6bO/6M9utxYKVZ3PCJ1rWxw==}
@@ -912,10 +912,6 @@ packages:
     resolution: {integrity: sha512-8olpW6mKCa0v+ibCjoCzgZHQx1SQmZuW/WkrdZo73wiTprTH6qhmskT60QLFdT9DRa5mXxjz89kQPZ7ZSsoqqg==}
     engines: {node: '>=16.0.0'}
 
-  '@smithy/core@3.18.5':
-    resolution: {integrity: sha512-6gnIz3h+PEPQGDj8MnRSjDvKBah042jEoPgjFGJ4iJLBE78L4lY/n98x14XyPF4u3lN179Ub/ZKFY5za9GeLQw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/core@3.24.6':
     resolution: {integrity: sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug==}
     engines: {node: '>=18.0.0'}
@@ -923,10 +919,6 @@ packages:
   '@smithy/credential-provider-imds@3.2.8':
     resolution: {integrity: sha512-ZCY2yD0BY+K9iMXkkbnjo+08T2h8/34oHd0Jmh6BZUSZwaaGlGCyBT/3wnS7u7Xl33/EEfN4B6nQr3Gx5bYxgw==}
     engines: {node: '>=16.0.0'}
-
-  '@smithy/credential-provider-imds@4.2.5':
-    resolution: {integrity: sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==}
-    engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.3.8':
     resolution: {integrity: sha512-5cAM+KZC02sTqDt6NaLXyu50M/GNMd1eTzDVR8Lb0BBsVtu7RWHo47VPPEEv1vt3Yub6uzr+M5FHC+GtoT0USg==}
@@ -957,10 +949,6 @@ packages:
 
   '@smithy/fetch-http-handler@4.1.3':
     resolution: {integrity: sha512-6SxNltSncI8s689nvnzZQc/dPXcpHQ34KUj6gR/HBroytKOd/isMG3gJF/zBE1TBmTT18TXyzhg3O3SOOqGEhA==}
-
-  '@smithy/fetch-http-handler@5.3.6':
-    resolution: {integrity: sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==}
-    engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.4.6':
     resolution: {integrity: sha512-FEwEYJ1jlBKdhe9TPzfghEi1bP55ZeEImlDkEa62bBBYzUcnB6RUCyuiS2mqKt6ZVjUbBgcNhzfIctH+Hevx9g==}
@@ -1053,10 +1041,6 @@ packages:
     resolution: {integrity: sha512-BrpZOaZ4RCbcJ2igiSNG16S+kgAc65l/2hmxWdmhyoGWHTLlzQzr06PXavJp9OBlPEG/sHlqdxjWmjzV66+BSQ==}
     engines: {node: '>=16.0.0'}
 
-  '@smithy/node-http-handler@4.4.5':
-    resolution: {integrity: sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/node-http-handler@4.7.7':
     resolution: {integrity: sha512-ZAFvHXrEk6K180EVhmZVg8GU5pUH5BSFqRs27JW3j1qEFx9YyYwWFx17x/MHcjALYimGAji7qEOlF1++be+G5A==}
     engines: {node: '>=18.0.0'}
@@ -1113,10 +1097,6 @@ packages:
     resolution: {integrity: sha512-5JWeMQYg81TgU4cG+OexAWdvDTs5JDdbEZx+Qr1iPbvo91QFGzjy0IkXAKaXUHqmKUJgSHK0ZxnCkgZpzkeNTA==}
     engines: {node: '>=16.0.0'}
 
-  '@smithy/signature-v4@5.3.5':
-    resolution: {integrity: sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/signature-v4@5.4.6':
     resolution: {integrity: sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ==}
     engines: {node: '>=18.0.0'}
@@ -1135,10 +1115,6 @@ packages:
 
   '@smithy/types@4.14.3':
     resolution: {integrity: sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ==}
-    engines: {node: '>=18.0.0'}
-
-  '@smithy/types@4.9.0':
-    resolution: {integrity: sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/url-parser@3.0.11':
@@ -1793,7 +1769,7 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -2417,9 +2393,6 @@ packages:
   strnum@1.1.2:
     resolution: {integrity: sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==}
 
-  strnum@2.1.1:
-    resolution: {integrity: sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==}
-
   strnum@2.4.0:
     resolution: {integrity: sha512-sHrVyWWdq28RbhjuJdZsA1SnGRJV6NiXbk6AXBxDOsgAcA+lmpUZCYjOdLBxkXMwis6RRe7dlZt4VlIWFVzkmg==}
 
@@ -2524,6 +2497,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   valibot@1.4.1:
@@ -2656,7 +2630,7 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.930.0
+      '@aws-sdk/types': 3.973.12
       tslib: 2.8.1
 
   '@aws-crypto/sha256-browser@5.2.0':
@@ -2681,7 +2655,7 @@ snapshots:
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.930.0
+      '@aws-sdk/types': 3.973.12
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
 
@@ -2749,8 +2723,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -2759,10 +2733,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -2795,11 +2769,11 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
+      '@smithy/core': 3.24.6
       '@smithy/eventstream-serde-browser': 4.2.5
       '@smithy/eventstream-serde-config-resolver': 4.3.5
       '@smithy/eventstream-serde-node': 4.2.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -2808,10 +2782,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -2842,8 +2816,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-compression': 4.3.12
@@ -2853,10 +2827,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -2889,8 +2863,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -2899,10 +2873,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -2934,8 +2908,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -2944,10 +2918,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -2979,8 +2953,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -2989,10 +2963,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -3025,8 +2999,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -3035,10 +3009,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -3053,18 +3027,54 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-lambda@3.1067.0':
+  '@aws-sdk/client-lambda@3.934.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.20
-      '@aws-sdk/credential-provider-node': 3.972.55
-      '@aws-sdk/types': 3.973.12
+      '@aws-sdk/core': 3.934.0
+      '@aws-sdk/credential-provider-node': 3.934.0
+      '@aws-sdk/middleware-host-header': 3.930.0
+      '@aws-sdk/middleware-logger': 3.930.0
+      '@aws-sdk/middleware-recursion-detection': 3.933.0
+      '@aws-sdk/middleware-user-agent': 3.934.0
+      '@aws-sdk/region-config-resolver': 3.930.0
+      '@aws-sdk/types': 3.930.0
+      '@aws-sdk/util-endpoints': 3.930.0
+      '@aws-sdk/util-user-agent-browser': 3.930.0
+      '@aws-sdk/util-user-agent-node': 3.934.0
+      '@smithy/config-resolver': 4.4.3
       '@smithy/core': 3.24.6
+      '@smithy/eventstream-serde-browser': 4.2.5
+      '@smithy/eventstream-serde-config-resolver': 4.3.5
+      '@smithy/eventstream-serde-node': 4.2.5
       '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/hash-node': 4.2.5
+      '@smithy/invalid-dependency': 4.2.5
+      '@smithy/middleware-content-length': 4.2.5
+      '@smithy/middleware-endpoint': 4.3.12
+      '@smithy/middleware-retry': 4.4.12
+      '@smithy/middleware-serde': 4.2.6
+      '@smithy/middleware-stack': 4.2.5
+      '@smithy/node-config-provider': 4.3.5
       '@smithy/node-http-handler': 4.7.7
+      '@smithy/protocol-http': 5.3.5
+      '@smithy/smithy-client': 4.9.8
       '@smithy/types': 4.14.3
+      '@smithy/url-parser': 4.2.5
+      '@smithy/util-base64': 4.3.0
+      '@smithy/util-body-length-browser': 4.2.0
+      '@smithy/util-body-length-node': 4.2.1
+      '@smithy/util-defaults-mode-browser': 4.3.11
+      '@smithy/util-defaults-mode-node': 4.2.14
+      '@smithy/util-endpoints': 3.2.5
+      '@smithy/util-middleware': 4.2.5
+      '@smithy/util-retry': 4.2.5
+      '@smithy/util-stream': 4.5.6
+      '@smithy/util-utf8': 4.2.0
+      '@smithy/util-waiter': 4.2.5
       tslib: 2.8.1
+    transitivePeerDependencies:
+      - aws-crt
 
   '@aws-sdk/client-opensearch@3.934.0':
     dependencies:
@@ -3082,8 +3092,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -3092,10 +3102,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -3127,8 +3137,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -3137,10 +3147,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -3185,8 +3195,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -3195,10 +3205,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -3229,8 +3239,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -3239,10 +3249,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -3274,8 +3284,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/md5-js': 4.2.5
@@ -3285,10 +3295,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -3406,8 +3416,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -3416,10 +3426,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -3495,13 +3505,13 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.930.0
       '@aws-sdk/xml-builder': 3.930.0
-      '@smithy/core': 3.18.5
+      '@smithy/core': 3.24.6
       '@smithy/node-config-provider': 4.3.5
       '@smithy/property-provider': 4.2.5
       '@smithy/protocol-http': 5.3.5
-      '@smithy/signature-v4': 5.3.5
+      '@smithy/signature-v4': 5.4.6
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-base64': 4.3.0
       '@smithy/util-middleware': 4.2.5
       '@smithy/util-utf8': 4.2.0
@@ -3530,7 +3540,7 @@ snapshots:
       '@aws-sdk/core': 3.934.0
       '@aws-sdk/types': 3.930.0
       '@smithy/property-provider': 4.2.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.46':
@@ -3557,12 +3567,12 @@ snapshots:
     dependencies:
       '@aws-sdk/core': 3.934.0
       '@aws-sdk/types': 3.930.0
-      '@smithy/fetch-http-handler': 5.3.6
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/property-provider': 4.2.5
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-stream': 4.5.6
       tslib: 2.8.1
 
@@ -3604,10 +3614,10 @@ snapshots:
       '@aws-sdk/credential-provider-web-identity': 3.934.0
       '@aws-sdk/nested-clients': 3.934.0
       '@aws-sdk/types': 3.930.0
-      '@smithy/credential-provider-imds': 4.2.5
+      '@smithy/credential-provider-imds': 4.3.8
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -3665,10 +3675,10 @@ snapshots:
       '@aws-sdk/credential-provider-sso': 3.934.0
       '@aws-sdk/credential-provider-web-identity': 3.934.0
       '@aws-sdk/types': 3.930.0
-      '@smithy/credential-provider-imds': 4.2.5
+      '@smithy/credential-provider-imds': 4.3.8
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -3701,7 +3711,7 @@ snapshots:
       '@aws-sdk/types': 3.930.0
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-process@3.972.46':
@@ -3733,7 +3743,7 @@ snapshots:
       '@aws-sdk/types': 3.930.0
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -3763,7 +3773,7 @@ snapshots:
       '@aws-sdk/types': 3.930.0
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -3788,7 +3798,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.930.0
       '@smithy/protocol-http': 5.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/middleware-logger@3.609.0':
@@ -3800,7 +3810,7 @@ snapshots:
   '@aws-sdk/middleware-logger@3.930.0':
     dependencies:
       '@aws-sdk/types': 3.930.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/middleware-recursion-detection@3.620.0':
@@ -3813,9 +3823,9 @@ snapshots:
   '@aws-sdk/middleware-recursion-detection@3.933.0':
     dependencies:
       '@aws-sdk/types': 3.930.0
-      '@aws/lambda-invoke-store': 0.2.0
+      '@aws/lambda-invoke-store': 0.2.4
       '@smithy/protocol-http': 5.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-ec2@3.930.0':
@@ -3824,9 +3834,9 @@ snapshots:
       '@aws-sdk/util-format-url': 3.930.0
       '@smithy/middleware-endpoint': 4.3.12
       '@smithy/protocol-http': 5.3.5
-      '@smithy/signature-v4': 5.3.5
+      '@smithy/signature-v4': 5.4.6
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-rds@3.930.0':
@@ -3835,8 +3845,8 @@ snapshots:
       '@aws-sdk/util-format-url': 3.930.0
       '@smithy/middleware-endpoint': 4.3.12
       '@smithy/protocol-http': 5.3.5
-      '@smithy/signature-v4': 5.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/middleware-sdk-s3@3.934.0':
@@ -3844,12 +3854,12 @@ snapshots:
       '@aws-sdk/core': 3.934.0
       '@aws-sdk/types': 3.930.0
       '@aws-sdk/util-arn-parser': 3.893.0
-      '@smithy/core': 3.18.5
+      '@smithy/core': 3.24.6
       '@smithy/node-config-provider': 4.3.5
       '@smithy/protocol-http': 5.3.5
-      '@smithy/signature-v4': 5.3.5
+      '@smithy/signature-v4': 5.4.6
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-middleware': 4.2.5
       '@smithy/util-stream': 4.5.6
@@ -3860,7 +3870,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.930.0
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-hex-encoding': 4.2.0
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
@@ -3878,9 +3888,9 @@ snapshots:
       '@aws-sdk/core': 3.934.0
       '@aws-sdk/types': 3.930.0
       '@aws-sdk/util-endpoints': 3.930.0
-      '@smithy/core': 3.18.5
+      '@smithy/core': 3.24.6
       '@smithy/protocol-http': 5.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.934.0':
@@ -3898,8 +3908,8 @@ snapshots:
       '@aws-sdk/util-user-agent-browser': 3.930.0
       '@aws-sdk/util-user-agent-node': 3.934.0
       '@smithy/config-resolver': 4.4.3
-      '@smithy/core': 3.18.5
-      '@smithy/fetch-http-handler': 5.3.6
+      '@smithy/core': 3.24.6
+      '@smithy/fetch-http-handler': 5.4.6
       '@smithy/hash-node': 4.2.5
       '@smithy/invalid-dependency': 4.2.5
       '@smithy/middleware-content-length': 4.2.5
@@ -3908,10 +3918,10 @@ snapshots:
       '@smithy/middleware-serde': 4.2.6
       '@smithy/middleware-stack': 4.2.5
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/node-http-handler': 4.4.5
+      '@smithy/node-http-handler': 4.7.7
       '@smithy/protocol-http': 5.3.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-base64': 4.3.0
       '@smithy/util-body-length-browser': 4.2.0
@@ -3953,7 +3963,7 @@ snapshots:
       '@aws-sdk/types': 3.930.0
       '@smithy/config-resolver': 4.4.3
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.934.0':
@@ -3961,8 +3971,8 @@ snapshots:
       '@aws-sdk/middleware-sdk-s3': 3.934.0
       '@aws-sdk/types': 3.930.0
       '@smithy/protocol-http': 5.3.5
-      '@smithy/signature-v4': 5.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/signature-v4': 5.4.6
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/signature-v4-multi-region@3.996.34':
@@ -3997,7 +4007,7 @@ snapshots:
       '@aws-sdk/types': 3.930.0
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
     transitivePeerDependencies:
       - aws-crt
@@ -4009,7 +4019,7 @@ snapshots:
 
   '@aws-sdk/types@3.930.0':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/types@3.973.12':
@@ -4031,7 +4041,7 @@ snapshots:
   '@aws-sdk/util-endpoints@3.930.0':
     dependencies:
       '@aws-sdk/types': 3.930.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-endpoints': 3.2.5
       tslib: 2.8.1
@@ -4040,7 +4050,7 @@ snapshots:
     dependencies:
       '@aws-sdk/types': 3.930.0
       '@smithy/querystring-builder': 4.2.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.893.0':
@@ -4057,7 +4067,7 @@ snapshots:
   '@aws-sdk/util-user-agent-browser@3.930.0':
     dependencies:
       '@aws-sdk/types': 3.930.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       bowser: 2.12.1
       tslib: 2.8.1
 
@@ -4073,12 +4083,12 @@ snapshots:
       '@aws-sdk/middleware-user-agent': 3.934.0
       '@aws-sdk/types': 3.930.0
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.930.0':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       fast-xml-parser: 5.2.5
       tslib: 2.8.1
 
@@ -4087,8 +4097,6 @@ snapshots:
       '@smithy/types': 4.14.3
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
-
-  '@aws/lambda-invoke-store@0.2.0': {}
 
   '@aws/lambda-invoke-store@0.2.4': {}
 
@@ -4376,7 +4384,7 @@ snapshots:
 
   '@smithy/abort-controller@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/config-resolver@3.0.13':
@@ -4390,7 +4398,7 @@ snapshots:
   '@smithy/config-resolver@4.4.3':
     dependencies:
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-endpoints': 3.2.5
       '@smithy/util-middleware': 4.2.5
@@ -4407,19 +4415,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.8.1
 
-  '@smithy/core@3.18.5':
-    dependencies:
-      '@smithy/middleware-serde': 4.2.6
-      '@smithy/protocol-http': 5.3.5
-      '@smithy/types': 4.9.0
-      '@smithy/util-base64': 4.3.0
-      '@smithy/util-body-length-browser': 4.2.0
-      '@smithy/util-middleware': 4.2.5
-      '@smithy/util-stream': 4.5.6
-      '@smithy/util-utf8': 4.2.0
-      '@smithy/uuid': 1.1.0
-      tslib: 2.8.1
-
   '@smithy/core@3.24.6':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
@@ -4434,14 +4429,6 @@ snapshots:
       '@smithy/url-parser': 3.0.11
       tslib: 2.8.1
 
-  '@smithy/credential-provider-imds@4.2.5':
-    dependencies:
-      '@smithy/node-config-provider': 4.3.5
-      '@smithy/property-provider': 4.2.5
-      '@smithy/types': 4.9.0
-      '@smithy/url-parser': 4.2.5
-      tslib: 2.8.1
-
   '@smithy/credential-provider-imds@4.3.8':
     dependencies:
       '@smithy/core': 3.24.6
@@ -4451,31 +4438,31 @@ snapshots:
   '@smithy/eventstream-codec@4.2.5':
     dependencies:
       '@aws-crypto/crc32': 5.2.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-hex-encoding': 4.2.0
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-browser@4.2.5':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-config-resolver@4.3.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-node@4.2.5':
     dependencies:
       '@smithy/eventstream-serde-universal': 4.2.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/eventstream-serde-universal@4.2.5':
     dependencies:
       '@smithy/eventstream-codec': 4.2.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@3.2.9':
@@ -4494,14 +4481,6 @@ snapshots:
       '@smithy/util-base64': 3.0.0
       tslib: 2.8.1
 
-  '@smithy/fetch-http-handler@5.3.6':
-    dependencies:
-      '@smithy/protocol-http': 5.3.5
-      '@smithy/querystring-builder': 4.2.5
-      '@smithy/types': 4.9.0
-      '@smithy/util-base64': 4.3.0
-      tslib: 2.8.1
-
   '@smithy/fetch-http-handler@5.4.6':
     dependencies:
       '@smithy/core': 3.24.6
@@ -4517,7 +4496,7 @@ snapshots:
 
   '@smithy/hash-node@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-buffer-from': 4.2.0
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
@@ -4529,7 +4508,7 @@ snapshots:
 
   '@smithy/invalid-dependency@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/is-array-buffer@2.2.0':
@@ -4546,17 +4525,17 @@ snapshots:
 
   '@smithy/md5-js@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
   '@smithy/middleware-compression@4.3.12':
     dependencies:
-      '@smithy/core': 3.18.5
+      '@smithy/core': 3.24.6
       '@smithy/is-array-buffer': 4.2.0
       '@smithy/node-config-provider': 4.3.5
       '@smithy/protocol-http': 5.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-config-provider': 4.2.0
       '@smithy/util-middleware': 4.2.5
       '@smithy/util-utf8': 4.2.0
@@ -4572,7 +4551,7 @@ snapshots:
   '@smithy/middleware-content-length@4.2.5':
     dependencies:
       '@smithy/protocol-http': 5.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/middleware-endpoint@3.2.8':
@@ -4588,11 +4567,11 @@ snapshots:
 
   '@smithy/middleware-endpoint@4.3.12':
     dependencies:
-      '@smithy/core': 3.18.5
+      '@smithy/core': 3.24.6
       '@smithy/middleware-serde': 4.2.6
       '@smithy/node-config-provider': 4.3.5
       '@smithy/shared-ini-file-loader': 4.4.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/url-parser': 4.2.5
       '@smithy/util-middleware': 4.2.5
       tslib: 2.8.1
@@ -4615,7 +4594,7 @@ snapshots:
       '@smithy/protocol-http': 5.3.5
       '@smithy/service-error-classification': 4.2.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-middleware': 4.2.5
       '@smithy/util-retry': 4.2.5
       '@smithy/uuid': 1.1.0
@@ -4629,7 +4608,7 @@ snapshots:
   '@smithy/middleware-serde@4.2.6':
     dependencies:
       '@smithy/protocol-http': 5.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/middleware-stack@3.0.11':
@@ -4639,7 +4618,7 @@ snapshots:
 
   '@smithy/middleware-stack@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/node-config-provider@3.1.12':
@@ -4653,7 +4632,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.5
       '@smithy/shared-ini-file-loader': 4.4.0
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/node-http-handler@3.3.3':
@@ -4662,14 +4641,6 @@ snapshots:
       '@smithy/protocol-http': 4.1.8
       '@smithy/querystring-builder': 3.0.11
       '@smithy/types': 3.7.2
-      tslib: 2.8.1
-
-  '@smithy/node-http-handler@4.4.5':
-    dependencies:
-      '@smithy/abort-controller': 4.2.5
-      '@smithy/protocol-http': 5.3.5
-      '@smithy/querystring-builder': 4.2.5
-      '@smithy/types': 4.9.0
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.7.7':
@@ -4685,7 +4656,7 @@ snapshots:
 
   '@smithy/property-provider@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/protocol-http@4.1.8':
@@ -4695,7 +4666,7 @@ snapshots:
 
   '@smithy/protocol-http@5.3.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/querystring-builder@3.0.11':
@@ -4706,7 +4677,7 @@ snapshots:
 
   '@smithy/querystring-builder@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-uri-escape': 4.2.0
       tslib: 2.8.1
 
@@ -4717,7 +4688,7 @@ snapshots:
 
   '@smithy/querystring-parser@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/service-error-classification@3.0.11':
@@ -4726,7 +4697,7 @@ snapshots:
 
   '@smithy/service-error-classification@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
 
   '@smithy/shared-ini-file-loader@3.1.12':
     dependencies:
@@ -4735,7 +4706,7 @@ snapshots:
 
   '@smithy/shared-ini-file-loader@4.4.0':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/signature-v4@4.2.4':
@@ -4747,17 +4718,6 @@ snapshots:
       '@smithy/util-middleware': 3.0.11
       '@smithy/util-uri-escape': 3.0.0
       '@smithy/util-utf8': 3.0.0
-      tslib: 2.8.1
-
-  '@smithy/signature-v4@5.3.5':
-    dependencies:
-      '@smithy/is-array-buffer': 4.2.0
-      '@smithy/protocol-http': 5.3.5
-      '@smithy/types': 4.9.0
-      '@smithy/util-hex-encoding': 4.2.0
-      '@smithy/util-middleware': 4.2.5
-      '@smithy/util-uri-escape': 4.2.0
-      '@smithy/util-utf8': 4.2.0
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.4.6':
@@ -4778,11 +4738,11 @@ snapshots:
 
   '@smithy/smithy-client@4.9.8':
     dependencies:
-      '@smithy/core': 3.18.5
+      '@smithy/core': 3.24.6
       '@smithy/middleware-endpoint': 4.3.12
       '@smithy/middleware-stack': 4.2.5
       '@smithy/protocol-http': 5.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       '@smithy/util-stream': 4.5.6
       tslib: 2.8.1
 
@@ -4791,10 +4751,6 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.14.3':
-    dependencies:
-      tslib: 2.8.1
-
-  '@smithy/types@4.9.0':
     dependencies:
       tslib: 2.8.1
 
@@ -4807,7 +4763,7 @@ snapshots:
   '@smithy/url-parser@4.2.5':
     dependencies:
       '@smithy/querystring-parser': 4.2.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/util-base64@3.0.0':
@@ -4873,7 +4829,7 @@ snapshots:
     dependencies:
       '@smithy/property-provider': 4.2.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/util-defaults-mode-node@3.0.34':
@@ -4889,11 +4845,11 @@ snapshots:
   '@smithy/util-defaults-mode-node@4.2.14':
     dependencies:
       '@smithy/config-resolver': 4.4.3
-      '@smithy/credential-provider-imds': 4.2.5
+      '@smithy/credential-provider-imds': 4.3.8
       '@smithy/node-config-provider': 4.3.5
       '@smithy/property-provider': 4.2.5
       '@smithy/smithy-client': 4.9.8
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/util-endpoints@2.1.7':
@@ -4905,7 +4861,7 @@ snapshots:
   '@smithy/util-endpoints@3.2.5':
     dependencies:
       '@smithy/node-config-provider': 4.3.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/util-hex-encoding@3.0.0':
@@ -4923,7 +4879,7 @@ snapshots:
 
   '@smithy/util-middleware@4.2.5':
     dependencies:
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/util-retry@3.0.11':
@@ -4935,7 +4891,7 @@ snapshots:
   '@smithy/util-retry@4.2.5':
     dependencies:
       '@smithy/service-error-classification': 4.2.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/util-stream@3.3.4':
@@ -4951,9 +4907,9 @@ snapshots:
 
   '@smithy/util-stream@4.5.6':
     dependencies:
-      '@smithy/fetch-http-handler': 5.3.6
-      '@smithy/node-http-handler': 4.4.5
-      '@smithy/types': 4.9.0
+      '@smithy/fetch-http-handler': 5.4.6
+      '@smithy/node-http-handler': 4.7.7
+      '@smithy/types': 4.14.3
       '@smithy/util-base64': 4.3.0
       '@smithy/util-buffer-from': 4.2.0
       '@smithy/util-hex-encoding': 4.2.0
@@ -4992,7 +4948,7 @@ snapshots:
   '@smithy/util-waiter@4.2.5':
     dependencies:
       '@smithy/abort-controller': 4.2.5
-      '@smithy/types': 4.9.0
+      '@smithy/types': 4.14.3
       tslib: 2.8.1
 
   '@smithy/uuid@1.1.0':
@@ -5578,7 +5534,7 @@ snapshots:
 
   fast-xml-parser@5.2.5:
     dependencies:
-      strnum: 2.1.1
+      strnum: 2.4.0
 
   fast-xml-parser@5.7.3:
     dependencies:
@@ -6357,8 +6313,6 @@ snapshots:
       js-tokens: 9.0.1
 
   strnum@1.1.2: {}
-
-  strnum@2.1.1: {}
 
   strnum@2.4.0:
     dependencies:

--- a/handlers/src/alarm-configs/_index.mts
+++ b/handlers/src/alarm-configs/_index.mts
@@ -5,6 +5,7 @@ export {ALB_CONFIGS} from './alb-configs.mjs';
 export {CLOUDFRONT_CONFIGS} from './cloudfront-configs.mjs';
 export {EC2_CONFIGS} from './ec2-configs.mjs';
 export {ECS_CONFIGS} from './ecs-configs.mjs';
+export {LAMBDA_CONFIGS} from './lambda-configs.mjs';
 export {OPENSEARCH_CONFIGS} from './opensearch-configs.mjs';
 export {RDS_CLUSTER_CONFIGS} from './rds-cluster-configs.mjs';
 export {RDS_CONFIGS} from './rds-configs.mjs';

--- a/handlers/src/alarm-configs/lambda-configs.mts
+++ b/handlers/src/alarm-configs/lambda-configs.mts
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview LAMBDA alarm configuration definitions.
+ *
+ * This file contains the default configurations for all supported LAMBDA CloudWatch alarms managed by AutoAlarm.
+ *
+ * @requires
+ * - Approval from Owners Team lead and consultation before adding new alarms
+ * - Anomaly Alarms can only use the following comparison operators: GreaterThanUpperThreshold, LessThanLowerOrGreaterThanUpperThreshold, LessThanLowerThreshold
+ *
+ * @Owners HARMONY-DEVOPS
+ */
+
+import {MetricAlarmConfig} from '../types/index.mjs';
+import {ComparisonOperator} from '@aws-sdk/client-cloudwatch';
+import {TreatMissingData} from 'aws-cdk-lib/aws-cloudwatch';
+
+/**
+ * LAMBDA alarm configuration definitions.
+ * Implements the {@link MetricAlarmConfig} interface.
+ * Used to map a tag key to a CloudWatch metric name and namespace to default alarm configurations {@link MetricAlarmOptions}.
+ */
+export const LAMBDA_CONFIGS: MetricAlarmConfig[] = [
+  {
+    tagKey: 'errors',
+    metricName: 'Errors',
+    metricNamespace: 'AWS/Lambda',
+    defaultCreate: true,
+    anomaly: false,
+    defaults: {
+      warningThreshold: null,
+      criticalThreshold: 1,
+      period: 60,
+      evaluationPeriods: 1,
+      statistic: 'Sum',
+      dataPointsToAlarm: 1,
+      comparisonOperator: ComparisonOperator.GreaterThanThreshold,
+      missingDataTreatment: TreatMissingData.IGNORE,
+    },
+  },
+] as const;

--- a/handlers/src/alarm-configs/lambda-configs.mts
+++ b/handlers/src/alarm-configs/lambda-configs.mts
@@ -28,12 +28,15 @@ export const LAMBDA_CONFIGS: MetricAlarmConfig[] = [
     anomaly: false,
     defaults: {
       warningThreshold: null,
+      // "Any error triggers the alarm": Errors is a Sum, so a single error in
+      // a period gives Sum=1. Use >= 1 (not > 1, which would require 2 errors,
+      // and not > 0 which is equivalent but less explicit) so one error fires.
       criticalThreshold: 1,
       period: 60,
       evaluationPeriods: 1,
       statistic: 'Sum',
       dataPointsToAlarm: 1,
-      comparisonOperator: ComparisonOperator.GreaterThanThreshold,
+      comparisonOperator: ComparisonOperator.GreaterThanOrEqualToThreshold,
       missingDataTreatment: TreatMissingData.IGNORE,
     },
   },

--- a/handlers/src/event-router.mts
+++ b/handlers/src/event-router.mts
@@ -337,6 +337,23 @@ export const eventRoutes: RouteEntry[] = [
     matches: source('aws.states'),
     action: module(ServiceModules.parseSFNEventAndCreateAlarms),
   },
+  {
+    // Lambda CloudTrail create/delete events. Current Lambda management
+    // events carry a "...v2" suffix (verified against a live us-west-2
+    // CloudTrail record: TagResource20170331v2), so both the legacy and v2
+    // names are matched for create and delete.
+    name: 'lambda',
+    matches: all(
+      source('aws.lambda'),
+      eventName(
+        'CreateFunction20150331',
+        'CreateFunction20150331v2',
+        'DeleteFunction20150331',
+        'DeleteFunction20150331v2',
+      ),
+    ),
+    action: module(ServiceModules.parseLambdaEventAndCreateAlarms),
+  },
 
   /*
    * aws.tag — Tag Change on Resource events, keyed on detail.service and
@@ -450,6 +467,15 @@ export const eventRoutes: RouteEntry[] = [
     name: 'tag-step-functions',
     matches: all(source('aws.tag'), tagService('states')),
     action: module(ServiceModules.parseSFNEventAndCreateAlarms),
+  },
+  {
+    name: 'tag-lambda',
+    matches: all(
+      source('aws.tag'),
+      tagService('lambda'),
+      tagResourceType('function'),
+    ),
+    action: module(ServiceModules.parseLambdaEventAndCreateAlarms),
   },
   {
     name: 'tag-unhandled-service',

--- a/handlers/src/event-router.test.mts
+++ b/handlers/src/event-router.test.mts
@@ -140,6 +140,30 @@ describe('direct event sources', () => {
     expect(decision.name).toBe('step-functions');
     expectModule(decision, ServiceModules.parseSFNEventAndCreateAlarms);
   });
+
+  test('aws.lambda create/delete routes to the Lambda module', () => {
+    // Lambda records the create API with a version suffix; both names match.
+    for (const name of [
+      'CreateFunction20150331',
+      'CreateFunction20150331v2',
+      'DeleteFunction20150331',
+      'DeleteFunction20150331v2',
+    ]) {
+      const decision = routeEvent(
+        cloudTrailEvent('aws.lambda', 'lambda.amazonaws.com', name),
+      );
+      expect(decision.name).toBe('lambda');
+      expectModule(decision, ServiceModules.parseLambdaEventAndCreateAlarms);
+    }
+  });
+
+  test('aws.lambda with an unversioned/unhandled eventName falls through to unhandled', () => {
+    const decision = routeEvent(
+      cloudTrailEvent('aws.lambda', 'lambda.amazonaws.com', 'CreateFunction'),
+    );
+    expect(decision.name).toBe('unhandled-event-source');
+    expect(decision.action.kind).toBe('fail');
+  });
 });
 
 describe('aws.ec2 events', () => {
@@ -406,8 +430,20 @@ describe('aws.tag events', () => {
     expectModule(decision, ServiceModules.parseSFNEventAndCreateAlarms);
   });
 
+  test('lambda tag events route to the Lambda module', () => {
+    const decision = routeEvent(
+      tagEvent(
+        'lambda',
+        'function',
+        'arn:aws:lambda:us-west-2:123456789012:function:my-function',
+      ),
+    );
+    expect(decision.name).toBe('tag-lambda');
+    expectModule(decision, ServiceModules.parseLambdaEventAndCreateAlarms);
+  });
+
   test('tag events for an unhandled service are skipped with a warning', () => {
-    const decision = routeEvent(tagEvent('lambda', 'function'));
+    const decision = routeEvent(tagEvent('kinesis', 'stream'));
     expect(decision.name).toBe('tag-unhandled-service');
     expect(decision.action.kind).toBe('skip');
   });
@@ -424,19 +460,19 @@ describe('aws.tag events', () => {
 describe('unmatched events', () => {
   test('unknown source produces a failure decision (warn + batch item failure)', () => {
     const decision = routeEvent({
-      'source': 'aws.lambda',
+      'source': 'aws.kinesis',
       'detail-type': 'AWS API Call via CloudTrail',
       'detail': {
-        eventSource: 'lambda.amazonaws.com',
-        eventName: 'CreateFunction',
+        eventSource: 'kinesis.amazonaws.com',
+        eventName: 'CreateStream',
       },
     });
     expect(decision.name).toBe('unhandled-event-source');
     expect(decision.action.kind).toBe('fail');
     if (decision.action.kind === 'fail') {
       expect(decision.action.level).toBe('warn');
-      expect(decision.action.message({source: 'aws.lambda'})).toBe(
-        'Unhandled event source: aws.lambda',
+      expect(decision.action.message({source: 'aws.kinesis'})).toBe(
+        'Unhandled event source: aws.kinesis',
       );
     }
   });

--- a/handlers/src/service-modules/_index.mts
+++ b/handlers/src/service-modules/_index.mts
@@ -22,3 +22,4 @@ export {parseRDSEventAndCreateAlarms} from './rds-modules.mjs';
 export {parseRDSClusterEventAndCreateAlarms} from './rds-cluster-modules.mjs';
 export {parseSFNEventAndCreateAlarms} from './step-function-modules.mjs';
 export {parseLogGroupEventAndCreateAlarms} from './loggroup-modules.mjs';
+export {parseLambdaEventAndCreateAlarms} from './lambda-modules.mjs';

--- a/handlers/src/service-modules/lambda-modules.mts
+++ b/handlers/src/service-modules/lambda-modules.mts
@@ -20,17 +20,16 @@ const lambdaClient: LambdaClient = new LambdaClient({
 const metricConfigs = LAMBDA_CONFIGS;
 
 export async function fetchLambdaTags(functionArn: string): Promise<Tag> {
-  return fetchResourceTags(
-    'Lambda',
-    functionArn,
-    async () => {
-      const command = new ListTagsCommand({Resource: functionArn});
-      const response = await lambdaClient.send(command);
-      // Lambda returns tags as a flat key/value map already.
-      return response.Tags ?? {};
-    },
-    'return-empty',
-  );
+  // Default 'rethrow' (not 'return-empty'): a transient ListTags failure must
+  // fail the SQS record for retry, not be treated as "no tags" — which would
+  // make manageServiceAlarms see autoalarm:enabled absent and delete every
+  // alarm for the function. See fetchResourceTags in service-helpers.mts.
+  return fetchResourceTags('Lambda', functionArn, async () => {
+    const command = new ListTagsCommand({Resource: functionArn});
+    const response = await lambdaClient.send(command);
+    // Lambda returns tags as a flat key/value map already.
+    return response.Tags ?? {};
+  });
 }
 
 async function checkAndManageLambdaAlarms(
@@ -64,9 +63,16 @@ export async function manageInactiveLambdaAlarms(
 /**
  * Extracts the Lambda function name from a function ARN or returns a bare
  * function name unchanged. The CloudWatch `FunctionName` dimension uses the
- * name, not the ARN.
+ * name, not the ARN, so a trailing version/alias qualifier is intentionally
+ * dropped: AutoAlarm monitors function-level errors.
  *
  * arn:aws:lambda:<region>:<account>:function:<name>[:<qualifier>]
+ *
+ * This does not cause prod/staging alias alarms to collide: Lambda tags can
+ * only be attached to the function resource itself (you cannot tag a version
+ * or alias), so every tag-change event — and every CloudTrail Create/Delete
+ * — carries the unqualified function ARN. There is no per-alias tag flow that
+ * could produce two identifiers to merge.
  */
 function extractFunctionName(functionArnOrName: string): string {
   if (!functionArnOrName) {

--- a/handlers/src/service-modules/lambda-modules.mts
+++ b/handlers/src/service-modules/lambda-modules.mts
@@ -1,0 +1,280 @@
+import {LambdaClient, ListTagsCommand} from '@aws-sdk/client-lambda';
+import * as logging from '@nr1e/logging';
+import {Tag} from '../types/index.mjs';
+import {ConfiguredRetryStrategy} from '@smithy/util-retry';
+import {
+  deleteExistingAlarms,
+  fetchResourceTags,
+  manageServiceAlarms,
+} from '../alarm-configs/utils/index.mjs';
+import {LAMBDA_CONFIGS} from '../alarm-configs/_index.mjs';
+
+const log: logging.Logger = logging.getLogger('lambda-modules');
+const region = process.env.AWS_REGION;
+const retryStrategy = new ConfiguredRetryStrategy(20);
+const lambdaClient: LambdaClient = new LambdaClient({
+  region: region,
+  retryStrategy: retryStrategy,
+});
+
+const metricConfigs = LAMBDA_CONFIGS;
+
+export async function fetchLambdaTags(functionArn: string): Promise<Tag> {
+  return fetchResourceTags(
+    'Lambda',
+    functionArn,
+    async () => {
+      const command = new ListTagsCommand({Resource: functionArn});
+      const response = await lambdaClient.send(command);
+      // Lambda returns tags as a flat key/value map already.
+      return response.Tags ?? {};
+    },
+    'return-empty',
+  );
+}
+
+async function checkAndManageLambdaAlarms(
+  functionName: string,
+  tags: Tag,
+): Promise<void> {
+  await manageServiceAlarms({
+    service: 'Lambda',
+    identifier: functionName,
+    tags,
+    configs: metricConfigs,
+    dimensions: [{Name: 'FunctionName', Value: functionName}],
+  });
+}
+
+export async function manageInactiveLambdaAlarms(
+  functionName: string,
+): Promise<void> {
+  try {
+    await deleteExistingAlarms('Lambda', functionName, metricConfigs);
+  } catch (e) {
+    log
+      .error()
+      .str('function', 'manageInactiveLambdaAlarms')
+      .err(e)
+      .msg(`Error deleting Lambda alarms: ${e}`);
+    throw new Error(`Error deleting Lambda alarms: ${e}`);
+  }
+}
+
+/**
+ * Extracts the Lambda function name from a function ARN or returns a bare
+ * function name unchanged. The CloudWatch `FunctionName` dimension uses the
+ * name, not the ARN.
+ *
+ * arn:aws:lambda:<region>:<account>:function:<name>[:<qualifier>]
+ */
+function extractFunctionName(functionArnOrName: string): string {
+  if (!functionArnOrName) {
+    log
+      .error()
+      .str('function', 'extractFunctionName')
+      .str(
+        'functionArnOrName',
+        functionArnOrName ? functionArnOrName : 'undefined',
+      )
+      .msg('Invalid Lambda identifier: function name not found');
+    throw new Error('Invalid Lambda identifier: function name not found');
+  }
+  // Bare name (no ARN) — return as-is.
+  if (!functionArnOrName.startsWith('arn:')) {
+    return functionArnOrName;
+  }
+  // arn:aws:lambda:region:account:function:<name>[:<qualifier>]
+  const parts = functionArnOrName.split(':');
+  const functionSegmentIndex = parts.indexOf('function');
+  const name =
+    functionSegmentIndex >= 0 ? parts[functionSegmentIndex + 1] : undefined;
+  if (!name) {
+    log
+      .error()
+      .str('function', 'extractFunctionName')
+      .str('functionArnOrName', functionArnOrName)
+      .msg('Could not extract function name from Lambda ARN');
+    throw new Error('Could not extract function name from Lambda ARN');
+  }
+  log
+    .debug()
+    .str('function', 'extractFunctionName')
+    .str('functionArnOrName', functionArnOrName)
+    .str('functionName', name)
+    .msg('Extracted Lambda function name');
+  return name;
+}
+
+export async function parseLambdaEventAndCreateAlarms(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  event: Record<string, any>,
+): Promise<{
+  functionArn: string;
+  eventType: string;
+  tags: Record<string, string>;
+} | void> {
+  let functionArn: string = '';
+  let eventType: string = '';
+  let tags: Record<string, string> = {};
+
+  switch (event['detail-type']) {
+    case 'Tag Change on Resource':
+      functionArn = event.resources?.[0] ?? '';
+      if (!functionArn) {
+        log
+          .error()
+          .str('function', 'parseLambdaEventAndCreateAlarms')
+          .obj('event', event)
+          .msg('No Lambda ARN found in event for tag change event');
+        throw new Error('No Lambda ARN found in event');
+      }
+      eventType = 'TagChange';
+      log
+        .info()
+        .str('function', 'parseLambdaEventAndCreateAlarms')
+        .str('eventType', 'TagChange')
+        .str('functionArn', functionArn)
+        .str('changedTags', JSON.stringify(event.detail['changed-tag-keys']))
+        .msg('Processing Tag Change event');
+      tags = await fetchLambdaTags(functionArn);
+      log
+        .info()
+        .str('function', 'parseLambdaEventAndCreateAlarms')
+        .str('functionArn', functionArn)
+        .str('tags', JSON.stringify(tags))
+        .msg('Fetched tags for Lambda TagChange event');
+      break;
+
+    case 'AWS API Call via CloudTrail':
+      switch (event.detail.eventName) {
+        // Lambda records the create API with a version suffix; both the legacy
+        // and current (v2) names are matched so the rule fires regardless of
+        // which the account emits.
+        case 'CreateFunction20150331':
+        case 'CreateFunction20150331v2':
+          // Failed events (AccessDenied, etc.) have no responseElements — skip.
+          if (event.detail.errorCode) {
+            log
+              .info()
+              .str('function', 'parseLambdaEventAndCreateAlarms')
+              .str('errorCode', event.detail.errorCode)
+              .msg('Skipping failed CreateFunction event');
+            return;
+          }
+          functionArn = event.detail.responseElements?.functionArn ?? '';
+          if (!functionArn) {
+            log
+              .error()
+              .str('function', 'parseLambdaEventAndCreateAlarms')
+              .obj('event', event)
+              .msg('No Lambda ARN found in event for CreateFunction event');
+            throw new Error(
+              'No Lambda ARN found in event for AWS API Call via CloudTrail event',
+            );
+          }
+          eventType = 'Create';
+          log
+            .info()
+            .str('function', 'parseLambdaEventAndCreateAlarms')
+            .str('eventType', 'Create')
+            .str('functionArn', functionArn)
+            .str('requestId', event.detail.requestID)
+            .msg('Processing CreateFunction event');
+          tags = await fetchLambdaTags(functionArn);
+          log
+            .info()
+            .str('function', 'parseLambdaEventAndCreateAlarms')
+            .str('functionArn', functionArn)
+            .str('tags', JSON.stringify(tags))
+            .msg('Fetched tags for new CreateFunction event');
+          break;
+
+        case 'DeleteFunction20150331':
+        case 'DeleteFunction20150331v2':
+          // Failed events have no requestParameters — skip.
+          if (event.detail.errorCode) {
+            log
+              .info()
+              .str('function', 'parseLambdaEventAndCreateAlarms')
+              .str('errorCode', event.detail.errorCode)
+              .msg('Skipping failed DeleteFunction event');
+            return;
+          }
+          // DeleteFunction carries the function name (or ARN) in
+          // requestParameters.functionName, not in responseElements.
+          functionArn = event.detail.requestParameters?.functionName ?? '';
+          if (!functionArn) {
+            log
+              .error()
+              .str('function', 'parseLambdaEventAndCreateAlarms')
+              .obj('event', event)
+              .msg('No Lambda function name found in DeleteFunction event');
+            throw new Error(
+              'No Lambda function name found in DeleteFunction event',
+            );
+          }
+          eventType = 'Delete';
+          log
+            .info()
+            .str('function', 'parseLambdaEventAndCreateAlarms')
+            .str('eventType', 'Delete')
+            .str('functionArn', functionArn)
+            .str('requestId', event.detail.requestID)
+            .msg('Processing DeleteFunction event');
+          break;
+
+        default:
+          log
+            .error()
+            .str('function', 'parseLambdaEventAndCreateAlarms')
+            .str('eventName', event.detail.eventName)
+            .str('requestId', event.detail.requestID)
+            .msg('Unexpected CloudTrail event type');
+          throw new Error('Unexpected CloudTrail event type');
+      }
+      break;
+
+    default:
+      log
+        .error()
+        .str('function', 'parseLambdaEventAndCreateAlarms')
+        .str('detail-type', event['detail-type'])
+        .msg('Unexpected event type');
+      throw new Error('Unexpected event type');
+  }
+
+  const functionName = extractFunctionName(functionArn);
+
+  log
+    .info()
+    .str('function', 'parseLambdaEventAndCreateAlarms')
+    .str('functionArn', functionArn)
+    .str('functionName', functionName)
+    .str('eventType', eventType)
+    .msg('Finished processing Lambda event');
+
+  if (eventType === 'Create' || eventType === 'TagChange') {
+    log
+      .info()
+      .str('function', 'parseLambdaEventAndCreateAlarms')
+      .str('functionName', functionName)
+      .str(
+        'autoalarm:enabled',
+        tags['autoalarm:enabled']
+          ? tags['autoalarm:enabled']
+          : 'autoalarm tag does not exist',
+      )
+      .msg('Starting to manage Lambda alarms');
+    await checkAndManageLambdaAlarms(functionName, tags);
+  } else if (eventType === 'Delete') {
+    log
+      .info()
+      .str('function', 'parseLambdaEventAndCreateAlarms')
+      .str('functionName', functionName)
+      .msg('Starting to manage inactive Lambda alarms');
+    await manageInactiveLambdaAlarms(functionName);
+  }
+
+  return {functionArn, eventType, tags};
+}


### PR DESCRIPTION
## Summary

Adds **AWS Lambda** as a new AutoAlarm surface so any tagged function gets a CloudWatch alarm when it produces errors. There was previously no Lambda surface — `AWS/Lambda` metrics were unmonitored.

Modeled on the **Step Functions** surface (the closest analog: dual CloudTrail + tag-change triggers and an error-count alarm).

### Behavior
- One default alarm: `Errors` (`AWS/Lambda`, `Sum`, `criticalThreshold: 1`, 60s / 1 period, `defaultCreate: true`).
- `autoalarm:enabled=true` alone → `AutoAlarm-Lambda-<fn>-Errors-Critical` (no Warning, no other metric by default).
- Reconfigure via `autoalarm:errors=<8-field value>`; nullish (`-/-/…`) removes the alarm.

## Changes
**Handlers**
- `alarm-configs/lambda-configs.mts` — `LAMBDA_CONFIGS` (+ barrel export)
- `service-modules/lambda-modules.mts` — `parseLambdaEventAndCreateAlarms`, `fetchLambdaTags` (`lambda:ListTags`), `manageInactiveLambdaAlarms`, `FunctionName` dimension (+ barrel export)
- `event-router.mts` — `lambda` (CloudTrail) + `tag-lambda` (tag-change) routes

**CDK**
- `service-tag-keys.ts` — `lambda` → `['autoalarm:enabled', 'autoalarm:errors']`
- `service-eventbridge-subconstruct.ts` — Lambda descriptor (tag + CloudTrail rules) → `AutoAlarm-Lambda` queue
- `sqs-handler-subconstruct.ts` — `AutoAlarm-Lambda` queue + `-Failed` DLQ
- `main-function-subsconstruct.ts` — `lambda:ListTags` + `lambda:GetFunction` IAM grant

**Tests & docs**
- Drift-guard entry (`lambda: LAMBDA_CONFIGS`), new router test cases, updated CDK resource counts (queues 35→37, redrive 17→18)
- `TESTING_PLAN.md` — new surface row #15, cheap-real lifecycle list, scorecard row

## CloudTrail event names
Lambda's current CloudTrail management events carry a `…v2` suffix — **verified against a live us-west-2 CloudTrail record** (`TagResource20170331v2`). The create/delete matchers (router + CDK rule) include **both** legacy and `v2` names (`CreateFunction20150331[v2]`, `DeleteFunction20150331[v2]`) so they fire regardless of which AWS emits. The `aws.tag` path is independent and drives enable/disable/reconfigure on its own.

## Verification
- Handlers: `prettier + eslint + tsc` clean; **170 tests pass**
- CDK: `tsc` clean; **24 tests pass** (incl. drift guard + resource counts); `cdk synth` exits 0
- End-to-end (deployed) follows `TESTING_PLAN.md` §5 A–G + lifecycle for the Lambda surface

## Notes
- Adds `@aws-sdk/client-lambda` (handlers `package.json` + `pnpm-lock.yaml`).
- `CLAUDE.md` and `TESTING_PLAN.md` were previously untracked and are committed here per request; `.autoalarm-test/` run artifacts are intentionally excluded.