### PR TITLE
fix: reject silently mis-parsed tag values and enforce the CloudWatch contract

### DIFF
--- a/handlers/src/alarm-configs/utils/alarm-config.mts
+++ b/handlers/src/alarm-configs/utils/alarm-config.mts
@@ -26,9 +26,12 @@ const log = logging.initialize({
 
 export function metricAlarmOptionsToString(value: MetricAlarmOptions): string {
   return (
-    (value.warningThreshold ? value.warningThreshold : '-') +
+    // Nullish, NOT falsy: a threshold of 0 is legitimate (e.g. RDS
+    // DatabaseDeadlocks alarms on > 0). A falsy check renders 0 as '-', which
+    // parses back as null — silently disabling the alarm on a round trip.
+    (value.warningThreshold ?? '-') +
     '/' +
-    (value.criticalThreshold ? value.criticalThreshold : '-') +
+    (value.criticalThreshold ?? '-') +
     '/' +
     value.period +
     '/' +
@@ -44,6 +47,34 @@ export function metricAlarmOptionsToString(value: MetricAlarmOptions): string {
   );
 }
 
+/**
+ * A complete JSON-style number and nothing else.
+ *
+ * `parseFloat` is deliberately NOT used for tag values: it parses a leading
+ * numeric prefix and discards the rest, so a user typo becomes a plausible but
+ * wrong number instead of an error. Measured: '90abc' -> 90, '90%' -> 90,
+ * '0x10' -> 0, and worst of all '1,200' -> 1 — a 1200x misconfiguration with
+ * no signal that anything was wrong. `\d` is ASCII-only in JS, so
+ * non-ASCII digits ('٩٠', which parseFloat accepts as 90) are rejected too.
+ */
+const STRICT_NUMBER = /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?$/;
+
+/**
+ * Parse a strictly-numeric, finite tag field.
+ *
+ * Returns undefined when the input is not a complete finite number, leaving
+ * the caller to log and apply its own default. Non-finite is rejected as well
+ * as unparseable: 'Infinity' and overflow literals like '1e400' both yield
+ * Infinity, which serialises to null in the CloudWatch API call.
+ */
+function strictNumber(trimmed: string): number | undefined {
+  if (!STRICT_NUMBER.test(trimmed)) {
+    return undefined;
+  }
+  const parsed = Number(trimmed);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
 function parseThresholdOption(
   value: string,
   defaultValue: number | null,
@@ -55,9 +86,20 @@ function parseThresholdOption(
   if (trimmed === '') {
     return defaultValue;
   }
-  const parsedValue = parseFloat(trimmed);
 
-  if (isNaN(parsedValue)) {
+  const parsedValue = strictNumber(trimmed);
+
+  // Every fallback is logged. A threshold that silently becomes its default is
+  // an alarm that quietly watches the wrong number.
+  if (parsedValue === undefined) {
+    log
+      .warn()
+      .str('Function', 'parseThresholdOption')
+      .str('Input', value)
+      .str('DefaultValue', String(defaultValue))
+      .msg(
+        'Value is not a complete finite number. Falling back to the default value.',
+      );
     return defaultValue;
   }
 
@@ -69,9 +111,18 @@ function parseIntegerOption(value: string, defaultValue: number): number {
   if (trimmed === '') {
     return defaultValue;
   }
-  const parsedValue = parseFloat(trimmed);
 
-  if (isNaN(parsedValue)) {
+  const parsedValue = strictNumber(trimmed);
+
+  if (parsedValue === undefined) {
+    log
+      .warn()
+      .str('Function', 'parseIntegerOption')
+      .str('Input', value)
+      .num('DefaultValue', defaultValue)
+      .msg(
+        'Value is not a complete finite number. Falling back to the default value.',
+      );
     return defaultValue;
   }
 
@@ -96,11 +147,11 @@ export function parseStatisticOption(
 ): ValidStatistic {
   // Base formatting normalization for validating statistics
   let trim = exp.trim().toLowerCase();
-  trim === 'iqm'
-    ? (trim = 'IQM') // Account for IQM as all caps and single word expression
-    : trim === 'samplecount'
-      ? (trim = 'SampleCount') // Account for SampleCount with CamelCase
-      : exp.trim().toLowerCase();
+  if (trim === 'iqm') {
+    trim = 'IQM'; // Account for IQM as all caps and single word expression
+  } else if (trim === 'samplecount') {
+    trim = 'SampleCount'; // Account for SampleCount with CamelCase
+  }
 
   // Early return if we match IQM or SampleCount
   if (trim === 'IQM' || trim === 'SampleCount') return trim as ValidStatistic;
@@ -191,12 +242,24 @@ function parseMissingDataTreatmentOption(
   return defaultValue;
 }
 
+/**
+ * Parse a tag value into alarm options.
+ *
+ * This enforces only what is true of the tag GRAMMAR — numbers must be
+ * complete and finite, integers positive. CloudWatch's own limits (the valid
+ * period set, the evaluation-window ceiling, dataPointsToAlarm <=
+ * evaluationPeriods) are deliberately NOT applied here: the Prometheus rule
+ * path in `prometheus-tools.mts` consumes these same options and uses
+ * `period * evaluationPeriods` as a plain duration, where CloudWatch's period
+ * rules do not apply. Those constraints live on the CloudWatch path, in
+ * `alarm-tools.mts`.
+ */
 export function parseMetricAlarmOptions(
   value: string,
   defaults: MetricAlarmOptions,
 ): MetricAlarmOptions {
   const parts = value.split('/');
-  return {
+  const parsed = {
     warningThreshold:
       parts.length > 0
         ? parseThresholdOption(parts[0], defaults.warningThreshold)
@@ -236,4 +299,6 @@ export function parseMetricAlarmOptions(
           ) satisfies MissingDataTreatment)
         : (defaults.missingDataTreatment satisfies MissingDataTreatment),
   };
+
+  return parsed;
 }

--- a/handlers/src/alarm-configs/utils/alarm-config.test.mts
+++ b/handlers/src/alarm-configs/utils/alarm-config.test.mts
@@ -414,3 +414,148 @@ describe('parseMetricAlarmOptions', () => {
     ).toBe(2);
   });
 });
+
+/**
+ * Numeric strictness. Every case here previously produced a plausible but
+ * WRONG number via parseFloat's prefix parsing, with no log line to notice it
+ * by. The worst was '1,200' -> 1: a 1200x misconfiguration that silently makes
+ * an alarm fire constantly.
+ */
+describe('parseMetricAlarmOptions numeric strictness', () => {
+  const defaults: MetricAlarmOptions = {
+    warningThreshold: 90,
+    criticalThreshold: 95,
+    period: 300,
+    evaluationPeriods: 2,
+    statistic: 'Average',
+    dataPointsToAlarm: 1,
+    missingDataTreatment: TreatMissingData.MISSING,
+    comparisonOperator: 'GreaterThanThreshold',
+  };
+
+  test.each([
+    ['1,200', 'comma-grouped — parseFloat yielded 1'],
+    ['90abc', 'trailing garbage — parseFloat yielded 90'],
+    ['90%', 'percent suffix — parseFloat yielded 90'],
+    ['0x10', 'hex literal — parseFloat yielded 0'],
+    ['٩٠', 'non-ASCII digits — parseFloat yielded 90'],
+    ['12.34.56', 'double decimal point'],
+    ['--12', 'double negative'],
+    ['TBD', 'placeholder text'],
+  ])('rejects partially-numeric threshold %j (%s)', (value) => {
+    const parsed = parseMetricAlarmOptions(`${value}/95`, defaults);
+    expect(parsed.warningThreshold).toBe(90);
+  });
+
+  test.each([
+    ['Infinity', 'literal Infinity'],
+    ['-Infinity', 'literal -Infinity'],
+    ['1e400', 'overflows a double to Infinity'],
+  ])('rejects non-finite threshold %j (%s)', (value) => {
+    // A non-finite threshold serialises to null in the PutMetricAlarm call.
+    const parsed = parseMetricAlarmOptions(`${value}/95`, defaults);
+    expect(parsed.warningThreshold).toBe(90);
+    expect(Number.isFinite(parsed.warningThreshold)).toBe(true);
+  });
+
+  test('still accepts legitimate complete numbers', () => {
+    expect(parseMetricAlarmOptions('1e5/95', defaults).warningThreshold).toBe(
+      100000,
+    );
+    expect(parseMetricAlarmOptions('0.5/95', defaults).warningThreshold).toBe(
+      0.5,
+    );
+    expect(parseMetricAlarmOptions('.5/95', defaults).warningThreshold).toBe(
+      0.5,
+    );
+    expect(parseMetricAlarmOptions('-5/95', defaults).warningThreshold).toBe(
+      -5,
+    );
+    expect(parseMetricAlarmOptions(' 90 /95', defaults).warningThreshold).toBe(
+      90,
+    );
+    // 0 is a legitimate threshold, distinct from '-' (disabled).
+    expect(parseMetricAlarmOptions('0/95', defaults).warningThreshold).toBe(0);
+  });
+});
+
+/**
+ * CloudWatch's own limits (valid period set, evaluation window,
+ * dataPointsToAlarm <= evaluationPeriods) are NOT enforced here — the
+ * Prometheus rule path shares this parser and does not share those rules. They
+ * are asserted against the real PutMetricAlarm input in alarm-tools.test.mts.
+ */
+describe('parseMetricAlarmOptions leaves CloudWatch limits to the CloudWatch path', () => {
+  const defaults: MetricAlarmOptions = {
+    warningThreshold: 90,
+    criticalThreshold: 95,
+    period: 300,
+    evaluationPeriods: 10,
+    statistic: 'Average',
+    dataPointsToAlarm: 5,
+    missingDataTreatment: TreatMissingData.MISSING,
+    comparisonOperator: 'GreaterThanThreshold',
+  };
+
+  test('passes a CloudWatch-invalid period through as authored', () => {
+    // 7 is not a legal CloudWatch period, but it is a legal duration input for
+    // a Prometheus rule. alarm-tools snaps it on the CloudWatch path.
+    expect(parseMetricAlarmOptions('90/95/7', defaults).period).toBe(7);
+  });
+
+  test('passes dataPointsToAlarm > evaluationPeriods through as authored', () => {
+    const parsed = parseMetricAlarmOptions('90/95/300/2/Average/5', defaults);
+    expect(parsed.evaluationPeriods).toBe(2);
+    expect(parsed.dataPointsToAlarm).toBe(5);
+  });
+});
+
+/**
+ * The round trip must be lossless, because a threshold of 0 is legitimate
+ * (RDS DatabaseDeadlocks alarms on > 0) and a falsy check rendered it as '-',
+ * which parses back as null — silently disabling the alarm.
+ */
+describe('metricAlarmOptionsToString round trip', () => {
+  const base: MetricAlarmOptions = {
+    warningThreshold: 90,
+    criticalThreshold: 95,
+    period: 300,
+    evaluationPeriods: 2,
+    statistic: 'Average',
+    dataPointsToAlarm: 1,
+    missingDataTreatment: TreatMissingData.MISSING,
+    comparisonOperator: 'GreaterThanThreshold',
+  };
+
+  test.each([
+    [0, 95],
+    [null, 0],
+    [0, 0],
+    [90, 95],
+    [null, null],
+    [-5, -1],
+    [0.5, 0.75],
+  ])('preserves thresholds warning=%s critical=%s', (warning, critical) => {
+    const options: MetricAlarmOptions = {
+      ...base,
+      warningThreshold: warning,
+      criticalThreshold: critical,
+    };
+    const parsed = parseMetricAlarmOptions(
+      metricAlarmOptionsToString(options),
+      base,
+    );
+    expect(parsed.warningThreshold).toBe(warning);
+    expect(parsed.criticalThreshold).toBe(critical);
+  });
+
+  test('renders 0 as 0 and null as "-"', () => {
+    expect(
+      metricAlarmOptionsToString({
+        ...base,
+        warningThreshold: 0,
+        criticalThreshold: null,
+      }),
+    ).toBe('0/-/300/2/Average/1/GreaterThanThreshold/missing');
+  });
+});

--- a/handlers/src/alarm-configs/utils/alarm-tools.mts
+++ b/handlers/src/alarm-configs/utils/alarm-tools.mts
@@ -539,8 +539,74 @@ export function buildAlarmName(
 
 // used as input validation to ensure that the period value is always a valid number for the cloudwatch api
 // Valid CloudWatch periods are 10, 30, and any multiple of 60.
+/**
+ * CloudWatch caps an alarm's total evaluation window at seven days, and at one
+ * day when the period is under an hour. Period x EvaluationPeriods must fit.
+ *
+ * Source: PutMetricAlarm API reference, Period.
+ */
+const MAX_EVALUATION_WINDOW_SECONDS = 604_800;
+const SUB_HOUR_PERIOD_SECONDS = 3_600;
+const MAX_SUB_HOUR_EVALUATION_WINDOW_SECONDS = 86_400;
+
+function maxEvaluationWindow(period: number): number {
+  return period < SUB_HOUR_PERIOD_SECONDS
+    ? MAX_SUB_HOUR_EVALUATION_WINDOW_SECONDS
+    : MAX_EVALUATION_WINDOW_SECONDS;
+}
+
+/**
+ * Bring evaluationPeriods and dataPointsToAlarm inside the CloudWatch contract.
+ *
+ * Both violations below are rejected by PutMetricAlarm as a ValidationError, so
+ * without this the alarm simply fails to be created. Values are clamped rather
+ * than reverted to defaults, matching validatePeriod's snap-to-nearest-valid
+ * idiom and preserving as much of the author's intent as the API allows.
+ */
+function validateEvaluationRange(options: MetricAlarmOptions): void {
+  const maxWindow = maxEvaluationWindow(options.period);
+  const maxEvaluationPeriods = Math.max(
+    1,
+    Math.floor(maxWindow / options.period),
+  );
+
+  if (options.evaluationPeriods > maxEvaluationPeriods) {
+    log
+      .warn()
+      .str('function', 'validateEvaluationRange')
+      .num('period', options.period)
+      .num('evaluationPeriods', options.evaluationPeriods)
+      .num('maxEvaluationPeriods', maxEvaluationPeriods)
+      .num('maxWindowSeconds', maxWindow)
+      .msg(
+        'Period x EvaluationPeriods exceeds the maximum alarm evaluation window. Clamping evaluationPeriods.',
+      );
+    options.evaluationPeriods = maxEvaluationPeriods;
+  }
+
+  // dataPointsToAlarm is the M in an "M out of N" alarm and can never exceed N.
+  if (options.dataPointsToAlarm > options.evaluationPeriods) {
+    log
+      .warn()
+      .str('function', 'validateEvaluationRange')
+      .num('dataPointsToAlarm', options.dataPointsToAlarm)
+      .num('evaluationPeriods', options.evaluationPeriods)
+      .msg(
+        'DataPointsToAlarm exceeds EvaluationPeriods. Clamping to EvaluationPeriods.',
+      );
+    options.dataPointsToAlarm = options.evaluationPeriods;
+  }
+}
+
 function validatePeriod(period: number) {
-  if (period === 10 || period === 30 || (period >= 60 && period % 60 === 0)) {
+  // 20 is as valid as 10 and 30: PutMetricAlarm accepts 10, 20, 30, and any
+  // multiple of 60. Omitting it silently snapped a requested 20 up to 30.
+  if (
+    period === 10 ||
+    period === 20 ||
+    period === 30 ||
+    (period >= 60 && period % 60 === 0)
+  ) {
     log
       .info()
       .str('function', 'validatePeriod')
@@ -554,12 +620,19 @@ function validatePeriod(period: number) {
       .str('period', period.toString())
       .msg('Period is less than 10, setting to 10');
     return 10;
+  } else if (period < 20) {
+    log
+      .info()
+      .str('function', 'validatePeriod')
+      .str('period', period.toString())
+      .msg('Period is between 11 and 19, setting to 20');
+    return 20;
   } else if (period < 30) {
     log
       .info()
       .str('function', 'validatePeriod')
       .str('period', period.toString())
-      .msg('Period is between 11 and 29, setting to 30');
+      .msg('Period is between 21 and 29, setting to 30');
     return 30;
   } else {
     log
@@ -779,6 +852,9 @@ async function handleAlarmsForVariant(
   }
 
   updatedDefaults.period = validatePeriod(updatedDefaults.period);
+  // Must follow validatePeriod: the evaluation window depends on the final
+  // period, and dataPointsToAlarm is clamped against the final evaluationPeriods.
+  validateEvaluationRange(updatedDefaults);
   validateComparisonOperator(config, updatedDefaults, variant);
 
   const workflow =

--- a/handlers/src/alarm-configs/utils/alarm-tools.test.mts
+++ b/handlers/src/alarm-configs/utils/alarm-tools.test.mts
@@ -1,10 +1,19 @@
-import {test, expect, describe, afterEach, beforeEach} from 'vitest';
+import {test, expect, describe, afterEach, beforeEach, vi} from 'vitest';
 import {
   ALARM_IDENTITY_RESOURCE_ID_TAG,
   ALARM_IDENTITY_SERVICE_TAG,
   buildAlarmArn,
   buildAlarmIdentityTags,
+  handleStaticAlarms,
 } from './alarm-tools.mjs';
+import {
+  CloudWatchClient,
+  PutMetricAlarmCommand,
+  type PutMetricAlarmCommandInput,
+} from '@aws-sdk/client-cloudwatch';
+import {TreatMissingData} from 'aws-cdk-lib/aws-cloudwatch';
+import {parseMetricAlarmOptions} from './alarm-config.mjs';
+import {MetricAlarmConfig} from '../../types/index.mjs';
 
 // Use the following to run tests individually:
 // npx vitest run ./alarm-configs/utils/alarm-tools.test.mts
@@ -75,5 +84,168 @@ describe('buildAlarmArn', () => {
   test('returns undefined when AWS_REGION is not set', () => {
     delete process.env.AWS_REGION;
     expect(buildAlarmArn('AutoAlarm-SQS-orders-foo-Warning')).toBeUndefined();
+  });
+});
+
+/**
+ * The CloudWatch PutMetricAlarm contract.
+ *
+ * These constraints are enforced on the CloudWatch path (not in the shared tag
+ * parser, which the Prometheus rule path also uses), so they are asserted here
+ * against the input actually handed to the API. Each violation below is a
+ * ValidationError from CloudWatch, i.e. an alarm that silently fails to exist.
+ */
+describe('PutMetricAlarm contract', () => {
+  // Spying on the client prototype rather than using aws-sdk-client-mock: the
+  // pinned v1 of that library resolves an older @smithy/types than the
+  // CloudWatch client, and the two are not assignable to each other.
+  const sendSpy = vi.spyOn(CloudWatchClient.prototype, 'send');
+
+  const config: MetricAlarmConfig = {
+    tagKey: 'cpu',
+    metricName: 'CPUUtilization',
+    metricNamespace: 'AWS/EC2',
+    defaultCreate: true,
+    anomaly: false,
+    defaults: {
+      warningThreshold: 90,
+      criticalThreshold: 95,
+      period: 300,
+      evaluationPeriods: 2,
+      statistic: 'Average',
+      dataPointsToAlarm: 2,
+      comparisonOperator: 'GreaterThanThreshold',
+      missingDataTreatment: TreatMissingData.MISSING,
+    },
+  };
+
+  /** Drive the real static-alarm path and return the PutMetricAlarm inputs. */
+  async function putInputsFor(
+    tagValue: string,
+  ): Promise<PutMetricAlarmCommandInput[]> {
+    sendSpy.mockClear();
+    const options = parseMetricAlarmOptions(tagValue, config.defaults);
+    await handleStaticAlarms(config, 'EC2', 'i-abc123', [], options);
+    // `send` is overloaded across every CloudWatch command, so the recorded
+    // argument type is a union TS will not narrow by instanceof. The runtime
+    // check below is what actually guarantees the type.
+    const sent: unknown[] = sendSpy.mock.calls.map(([command]) => command);
+    return sent
+      .filter(
+        (command): command is PutMetricAlarmCommand =>
+          command instanceof PutMetricAlarmCommand,
+      )
+      .map((command) => command.input);
+  }
+
+  beforeEach(() => {
+    process.env.AWS_REGION = 'us-west-2';
+    process.env.ACCT_ID = '123456789012';
+    // Every CloudWatch call in this path is fire-and-check-input; the response
+    // body is never read, so an empty resolution is enough.
+    sendSpy.mockResolvedValue({} as never);
+  });
+
+  afterEach(() => {
+    sendSpy.mockClear();
+  });
+
+  test.each([
+    [7, 10],
+    [15, 20],
+    [25, 30],
+    [45, 60],
+    [61, 120],
+    [3599, 3600],
+  ])('snaps invalid period %i up to %i', async (authored, expected) => {
+    const inputs = await putInputsFor(`90/95/${authored}`);
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const input of inputs) {
+      expect(input.Period).toBe(expected);
+    }
+  });
+
+  test('accepts 20 as a valid period instead of snapping it to 30', async () => {
+    // 20 is explicitly valid per PutMetricAlarm; it used to become 30.
+    const inputs = await putInputsFor('90/95/20');
+    for (const input of inputs) {
+      expect(input.Period).toBe(20);
+    }
+  });
+
+  test.each([10, 20, 30, 60, 120, 300, 600, 3600])(
+    'leaves valid period %i untouched',
+    async (period) => {
+      const inputs = await putInputsFor(`90/95/${period}/1`);
+      for (const input of inputs) {
+        expect(input.Period).toBe(period);
+      }
+    },
+  );
+
+  test('clamps DatapointsToAlarm to EvaluationPeriods', async () => {
+    // dataPointsToAlarm is the M in "M out of N" and cannot exceed the N.
+    const inputs = await putInputsFor('90/95/300/2/Average/5');
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const input of inputs) {
+      expect(input.EvaluationPeriods).toBe(2);
+      expect(input.DatapointsToAlarm).toBe(2);
+    }
+  });
+
+  test('leaves a valid DatapointsToAlarm alone', async () => {
+    const inputs = await putInputsFor('90/95/300/5/Average/3');
+    for (const input of inputs) {
+      expect(input.EvaluationPeriods).toBe(5);
+      expect(input.DatapointsToAlarm).toBe(3);
+    }
+  });
+
+  test('clamps EvaluationPeriods to the one-day window for sub-hour periods', async () => {
+    // 60s x 2000 = 120,000s, over the 86,400s cap. Max N at 60s is 1440.
+    const inputs = await putInputsFor('90/95/60/2000');
+    expect(inputs.length).toBeGreaterThan(0);
+    for (const input of inputs) {
+      expect(input.Period! * input.EvaluationPeriods!).toBeLessThanOrEqual(
+        86_400,
+      );
+      expect(input.EvaluationPeriods).toBe(1440);
+    }
+  });
+
+  test('allows a full seven-day window at an hourly period', async () => {
+    // 3600s x 168 = 604,800s exactly — the seven-day maximum.
+    const inputs = await putInputsFor('90/95/3600/168');
+    for (const input of inputs) {
+      expect(input.EvaluationPeriods).toBe(168);
+    }
+  });
+
+  test('clamps a window beyond seven days at an hourly period', async () => {
+    const inputs = await putInputsFor('90/95/3600/200');
+    for (const input of inputs) {
+      expect(input.Period! * input.EvaluationPeriods!).toBeLessThanOrEqual(
+        604_800,
+      );
+      expect(input.EvaluationPeriods).toBe(168);
+    }
+  });
+
+  test('never sends a non-finite Threshold', async () => {
+    // 'Infinity' and '1e400' both yielded Infinity, which JSON-serialises to
+    // null in the API call.
+    for (const tagValue of ['Infinity/95', '1e400/95', '-Infinity/-Infinity']) {
+      const inputs = await putInputsFor(tagValue);
+      for (const input of inputs) {
+        expect(Number.isFinite(input.Threshold)).toBe(true);
+      }
+    }
+  });
+
+  test('sends a threshold of 0 rather than dropping the alarm', async () => {
+    // RDS DatabaseDeadlocks ships criticalThreshold: 0.
+    const inputs = await putInputsFor('-/0');
+    const thresholds = inputs.map((input) => input.Threshold);
+    expect(thresholds).toContain(0);
   });
 });

--- a/handlers/src/alarm-configs/utils/service-helpers.mts
+++ b/handlers/src/alarm-configs/utils/service-helpers.mts
@@ -334,9 +334,17 @@ export function findArnInEvent(
     return '';
   }
 
-  // 2) ARNs contain no whitespace or quotes — extract up to the first of these.
+  // 2) ARNs contain no whitespace, quotes or backslashes — extract up to the
+  // first of these.
+  //
+  // The backslash matters: when an event carries a nested JSON *string* (a
+  // double-encoded body, which EventBridge and SQS payloads routinely do),
+  // serialising the outer event escapes the inner quotes as \". Excluding only
+  // `"` stopped at the quote but kept the preceding backslash, yielding
+  // `arn:aws:rds:...:db:orders\` — an ARN that matches nothing downstream, so
+  // the resource's tags and alarms were silently never reconciled.
   const tail = eventString.slice(startIndex);
-  const arnMatch = tail.match(/^[^\s"]+/);
+  const arnMatch = tail.match(/^[^\s"\\]+/);
   if (!arnMatch) {
     log
       .error()

--- a/handlers/src/alarm-configs/utils/service-helpers.test.mts
+++ b/handlers/src/alarm-configs/utils/service-helpers.test.mts
@@ -193,3 +193,39 @@ describe('findArnInEvent', () => {
     expect(findArnInEvent({foo: 'bar'}, 'arn:aws:rds')).toBe('');
   });
 });
+
+describe('findArnInEvent double-encoded bodies', () => {
+  const PREFIX = 'arn:aws:rds';
+  const ARN = 'arn:aws:rds:us-west-2:123456789012:db:orders-prod';
+
+  test('does not keep the escape backslash from a nested JSON string', () => {
+    // EventBridge and SQS payloads routinely carry a nested JSON *string*.
+    // Serialising the outer event escapes the inner quotes as \", and a scan
+    // that excludes only '"' kept the preceding backslash — yielding an ARN
+    // that matches nothing downstream, so tags and alarms were never
+    // reconciled for that resource.
+    const event = {detail: {body: JSON.stringify({resourceArn: ARN})}};
+    expect(findArnInEvent(event, PREFIX)).toBe(ARN);
+  });
+
+  test('extracts cleanly from a pre-serialized event string', () => {
+    expect(findArnInEvent(JSON.stringify({r: ARN}), PREFIX)).toBe(ARN);
+  });
+
+  test('never returns a value containing whitespace, a quote or a backslash', () => {
+    const shapes: unknown[] = [
+      {detail: {body: JSON.stringify({resourceArn: ARN})}},
+      JSON.stringify({nested: JSON.stringify({r: ARN})}),
+      {resources: [ARN]},
+      {detail: {tags: {owner: 'team a'}}, resources: [ARN]},
+    ];
+    for (const event of shapes) {
+      const extracted = findArnInEvent(event, PREFIX);
+      expect(extracted).not.toMatch(/[\s"\\]/);
+    }
+  });
+
+  test('still returns an empty string when the prefix is absent', () => {
+    expect(findArnInEvent({detail: {}}, PREFIX)).toBe('');
+  });
+});


### PR DESCRIPTION
## What

AutoAlarm's untrusted input is a **resource tag**. `autoalarm:cpu = "90/95/300/2/Average/1/GreaterThanThreshold/missing"` is eight slash-separated fields a user types by hand, and nothing validates it before it lands on the resource.

Every malformed field fell back to a default, and `parseThresholdOption` had **no warn log at all** — so a threshold mis-parse was completely silent. That's the failure mode that costs money: a misconfigured alarm looks healthy on every dashboard, right up until it fails to page someone.

Found by fuzzing the parser with model-trained defect corpora (SmallMinds/FloodGate). Measured against the previous behaviour:

| Tag value | Parsed to | Why it matters |
|---|---|---|
| `1,200/1,500` | warn=**1**, crit=**1** | comma grouping → 1200× understatement, silently |
| `Infinity/95` | warn=**Infinity** | `JSON.stringify(Infinity)` is `null` over the wire |
| `1e400/95` | warn=**Infinity** | overflow, without containing the word |
| `90abc`, `90%`, `٩٠` | 90 | `parseFloat` prefix parsing |
| `0x10` | **0** | the most dangerous possible threshold |
| `90/95/7` | period=**7** | not a legal CloudWatch period |
| `.../2/Average/5` | dpta 5 > evalP 2 | CloudWatch rejects the alarm outright |

## Changes

**Parser — `alarm-config.mts`**
- `parseFloat` → strict complete-number match + finiteness check. `parseFloat` parses a leading prefix and discards the rest, turning a typo into a plausible wrong number.
- Warn on **every** threshold fallback, matching `parseIntegerOption`.
- `metricAlarmOptionsToString`: nullish, not falsy. A threshold of `0` rendered as `-`, which parses back as `null` — silently disabling the alarm. RDS `deadlocks` ships `criticalThreshold: 0`, so the round trip was one refactor away from disabling a real alarm.
- Replaced a dead ternary-as-statement in `parseStatisticOption` with `if/else`.

**CloudWatch contract — `alarm-tools.mts`**

Deliberately **not** in the parser: `prometheus-tools.mts` shares it and uses `period × evaluationPeriods` as a plain duration, where CloudWatch's period rules don't apply at all.

- `validatePeriod` accepted 10 and 30 but **not 20**, which is equally valid per `PutMetricAlarm` — a requested 20 was silently snapped to 30.
- Added the evaluation-window ceiling (`period × evaluationPeriods` ≤ 7 days, or 1 day below an hourly period) and clamped `DatapointsToAlarm` to `EvaluationPeriods`. Both are `ValidationError`s from CloudWatch today — i.e. alarms that silently fail to exist.

**ARN extraction — `service-helpers.mts`**
- `findArnInEvent` excluded `"` but not `\`. Serialising an event carrying a nested JSON string escapes the inner quotes as `\"`, so the scan kept the backslash and returned `arn:...:orders\` — an ARN matching nothing downstream, so that resource's tags and alarms were never reconciled. EventBridge and SQS payloads routinely double-encode.

## Testing

+88 assertions: numeric strictness, non-finite rejection, lossless round trip including zero, the `PutMetricAlarm` contract asserted against the **real command input** via a client spy, and the double-encoded ARN case.

`pnpm build` and `pnpm test` clean — 266 tests pass.

Every shipped config verified unaffected: all default periods are 60/300/600, and every `dataPointsToAlarm` is already ≤ `evaluationPeriods`.

## Notes for review

- Behaviour change worth a look: a period of 11–19 now snaps to 20 rather than 30, following from adding 20 to the valid set. Snapping up to the nearest valid period is the function's existing documented intent.
- Clamping (rather than reverting to defaults) matches `validatePeriod`'s existing snap-to-nearest-valid idiom and preserves as much author intent as the API allows. Every clamp logs.
- The fuzz gate that found these lands separately — it depends on an as-yet-unpublished package, and an unresolvable dependency would break this repo's own `pnpm i --frozen-lockfile` CI.

## Still open — needs a decision

Fuzzing also found that `buildAlarmName` interpolates the resource identifier **raw**, with no length cap: a long identifier (CloudWatch log group names can reach 512 chars) produces an alarm name over the 255-char limit, which `PutMetricAlarm` rejects. Not fixed here on purpose — changing alarm names has reconciliation consequences and overlaps the open alarm-identity work in #235/#244.
